### PR TITLE
Updating brief field of containers.ipkg to match README.md

### DIFF
--- a/containers.ipkg
+++ b/containers.ipkg
@@ -1,7 +1,7 @@
 package containers
 
 authors    = "stefan-hoeck and matthew-mosior"
-brief      = "Basic Tree and Queue data structures"
+brief      = "Assorted concrete container types"
 version    = 0.6.0
 sourcedir  = "src"
 depends    = base         >= 0.6.0


### PR DESCRIPTION
This PR updates the brief field of the `containers.ikpg` file to match the text in the `README.md`.

This closes https://github.com/stefan-hoeck/idris2-containers/issues/8.