### PR TITLE
[ doc ] Add Missing Documentation

### DIFF
--- a/src/Data/BoundedQueue.idr
+++ b/src/Data/BoundedQueue.idr
@@ -1,3 +1,4 @@
+||| Bounded Queues
 module Data.BoundedQueue
 
 import Data.Seq.Unsized

--- a/src/Data/Queue.idr
+++ b/src/Data/Queue.idr
@@ -1,3 +1,4 @@
+||| Immutable FIFO Queues.
 module Data.Queue
 
 import Derive.Prelude

--- a/src/Data/Tree.idr
+++ b/src/Data/Tree.idr
@@ -1,3 +1,4 @@
+||| Finite Rose Trees.
 module Data.Tree
 
 import Data.List


### PR DESCRIPTION
This PR adds missing header text to `BoundedQueue`, `Tree` and `Queue`.