### PR TITLE
[ doc ] Fixing documentation

### DIFF
--- a/src/Data/Queue.idr
+++ b/src/Data/Queue.idr
@@ -1,4 +1,4 @@
-||| Immutable FIFO Queues.
+||| Immutable FIFO Queues
 module Data.Queue
 
 import Derive.Prelude

--- a/src/Data/Tree.idr
+++ b/src/Data/Tree.idr
@@ -1,4 +1,4 @@
-||| Finite Rose Trees.
+||| Finite Rose Trees
 module Data.Tree
 
 import Data.List


### PR DESCRIPTION
This PR removes punctuation in the documentation for `Queue` and `Tree`.