### PR TITLE
[ ipkg ] add FVect and SnocVect modules to .ipkg file

### DIFF
--- a/containers.ipkg
+++ b/containers.ipkg
@@ -9,14 +9,18 @@ depends    = base         >= 0.6.0
            , elab-util
 
 modules = Data.BoundedQueue
+        , Data.FVect
+        , Data.FVect.Capacity
         , Data.Map
         , Data.Map.Internal
+        , Data.Queue
         , Data.RRBVector
         , Data.RRBVector.Internal
-        , Data.Set
-        , Data.Set.Internal
+        , Data.Seq.Internal
         , Data.Seq.Sized
         , Data.Seq.Unsized
-        , Data.Seq.Internal
-        , Data.Queue
+        , Data.Set
+        , Data.Set.Internal
+        , Data.SnocVect
+        , Data.SnocVect.Elem
         , Data.Tree

--- a/src/Data/SnocVect.idr
+++ b/src/Data/SnocVect.idr
@@ -148,10 +148,8 @@ public export
 Foldable (SnocVect n) where
   foldr f z = foldr f z . (<>> [])
 
-  foldl f z xs = h xs where
-    h : SnocVect k elem -> acc
-    h Lin = z
-    h (xs :< x) = f (h xs) x
+  foldl f z Lin     = z
+  foldl f z (xs:<x) = f (foldl f z xs) x
 
   null Lin      = True
   null (_ :< _) = False
@@ -167,7 +165,7 @@ public export
 
 ||| Get diagonal elements
 public export
-diag : SnocVect len (SnocVect len elem) -> SnocVect len elem
+diag : SnocVect len (SnocVect len el) -> SnocVect len el
 diag [<]             = [<]
 diag (ssx :< (sx :< x)) = diag (map liat ssx) :< x
 


### PR DESCRIPTION
This addes the modules from #17  and #18  to the `.ipkg` file and removes two shadowing warnings from `Data.SnocVect`.