### PR TITLE
[ refactor ] Remove derived `Eq` and `Ord` for RRBVector

### DIFF
--- a/src/Data/RRBVector/Internal.idr
+++ b/src/Data/RRBVector/Internal.idr
@@ -306,4 +306,4 @@ data RRBVector a = Root Nat   -- size
                         (Tree a)
                  | Empty
 
-%runElab derive "RRBVector" [Eq,Ord,Show]
+%runElab derive "RRBVector" [Show]


### PR DESCRIPTION
This PR removes the automatically derived `Eq` and `Ord` implementations for `RRBVector`.