### PR TITLE
[ refactor ] Split RRBVector1 into Sized and Unsized

### DIFF
--- a/containers.ipkg
+++ b/containers.ipkg
@@ -28,6 +28,7 @@ modules = Data.BoundedQueue
         , Data.RRBVector.Unsized
         , Data.RRBVector.Sized.Internal
         , Data.RRBVector.Unsized.Internal
+        , Data.RRBVector1.Sized
         , Data.RRBVector1.Unsized
         , Data.RRBVector1.Sized.Internal
         , Data.RRBVector1.Unsized.Internal

--- a/containers.ipkg
+++ b/containers.ipkg
@@ -28,8 +28,9 @@ modules = Data.BoundedQueue
         , Data.RRBVector.Unsized
         , Data.RRBVector.Sized.Internal
         , Data.RRBVector.Unsized.Internal
-        , Data.RRBVector1
-        , Data.RRBVector1.Internal
+        , Data.RRBVector1.Unsized
+        , Data.RRBVector1.Sized.Internal
+        , Data.RRBVector1.Unsized.Internal
         , Data.Seq.Internal
         , Data.Seq.Sized
         , Data.Seq.Unsized

--- a/src/Data/RRBVector1/Sized.idr
+++ b/src/Data/RRBVector1/Sized.idr
@@ -1,0 +1,1532 @@
+||| Linear Relaxed Radix Balanced Vectors (RRBVector1)
+module Data.RRBVector1.Sized
+
+import public Data.RRBVector1.Sized.Internal
+
+import Data.Array.Core
+import Data.Array.Index
+import Data.Array.Indexed
+import Data.Array.Mutable
+import Data.Bits
+import Data.Maybe
+import Data.Linear.Ref1
+import Data.List
+import Data.List1
+import Data.SnocList
+import Data.Vect
+import Data.Zippable
+
+%hide Data.Array.Core.take
+%hide Data.Array.Indexed.drop
+%hide Data.Linear.splitAt
+%hide Data.Linear.(::)
+%hide Data.List.drop
+%hide Data.List.lookup
+%hide Data.List.take
+%hide Data.List.singleton
+%hide Data.List1.singleton
+%hide Data.Vect.drop
+%hide Data.Vect.lookup
+%hide Data.Vect.splitAt
+%hide Data.Vect.take
+%hide Data.Vect.Stream.take
+%hide Data.Vect.(::)
+%hide Prelude.null
+%hide Prelude.take
+%hide Prelude.(|>)
+%hide Prelude.Ops.infixr.(<|)
+%hide Prelude.Ops.infixl.(|>)
+%hide Prelude.Stream.(::)
+
+%default total
+
+--------------------------------------------------------------------------------
+--          Fixity
+--------------------------------------------------------------------------------
+
+export
+infixr 5 ><
+
+export
+infixr 5 <|
+
+export
+infixl 5 |>
+
+--------------------------------------------------------------------------------
+--          Creating linear RRB-Vectors
+--------------------------------------------------------------------------------
+
+||| The empty vector. O(1)
+export
+empty : F1 s (RRBVector1 s Z a)
+empty t =
+  Empty # t
+
+||| A vector with a single element. O(1)
+export
+singleton :  a
+          -> F1 s (RRBVector1 s 1 a)
+singleton x t =
+  let newarr # t := marray1 1 x t
+    in Root 0 (Leaf {lsize=1} (1 ** newarr)) # t
+
+||| Create a new vector from a list. O(n)
+export
+fromList :  List a
+         -> F1 s (RRBVector1 s a)
+fromList []  t = empty t
+fromList [x] t = singleton x t
+fromList xs  t =
+  let trees # t := nodes xs Lin t
+    in case trees of
+         [tree] =>
+           let treesize # t := treeSize 0 tree t
+             in (Root treesize 0 tree) # t
+         xs'    =>
+           assert_smaller xs (iterateNodes blockshift xs' t)
+  where
+    nodes :  List a
+          -> SnocList (Tree1 s a)
+          -> F1 s (List (Tree1 s a))
+    nodes l sl with (splitAt blocksize l) | ((length (fst (splitAt blocksize l))) <= (length l)) proof eq
+      _ | (cl, cl') | True  = \t =>
+        let trees'  # t := unsafeMArray1 (length l) t
+            ()      # t := writeList trees' l t
+            trees'' # t := mtake trees' (length (fst (splitAt blocksize l))) @{lteOpReflectsLTE _ _ eq} t
+          in case cl' of
+               []   =>
+                 let trees''' := Leaf {lsize=(length (fst (splitAt blocksize l)))} ((length (fst (splitAt blocksize l))) ** trees'')
+                     sl'      := sl :< trees'''
+                   in (sl' <>> []) # t
+               cl'' =>
+                 let trees''' := Leaf {lsize=(length (fst (splitAt blocksize l)))} ((length (fst (splitAt blocksize l))) ** trees'')
+                     sl'      := sl :< trees'''
+                   in (nodes (assert_smaller l cl'') sl') t
+      _ | _         | False = \t =>
+        (assert_total $ idris_crash "Data.RRBVector1.fromList.nodes: index out of bounds") # t
+    nodes' :  Nat
+           -> List (Tree1 s a)
+           -> SnocList (Tree1 s a)
+           -> F1 s (List (Tree1 s a))
+    nodes' sh l sl with (splitAt blocksize l) | ((length (fst (splitAt blocksize l))) <= (length l)) proof eq
+      _ | (cl, cl') | True  = \t =>
+        let trees'  # t := unsafeMArray1 (length l) t
+            ()      # t := writeList trees' l t
+            trees'' # t := mtake trees' (length (fst (splitAt blocksize l))) @{lteOpReflectsLTE _ _ eq} t
+          in case cl' of
+               []   =>
+                 let trees''' := Balanced {bsize=(length (fst (splitAt blocksize l)))} ((length (fst (splitAt blocksize l))) ** trees'')
+                     sl'      := sl :< trees'''
+                   in (sl' <>> []) # t
+               cl'' =>
+                 let trees''' := Balanced {bsize=(length (fst (splitAt blocksize l)))} ((length (fst (splitAt blocksize l))) ** trees'')
+                     sl'      := sl :< trees'''
+                   in (nodes' sh (assert_smaller l cl'') sl') t
+      _ | _         | False = \t =>
+        (assert_total $ idris_crash "Data.RRBVector1.fromList.nodes': index out of bounds") # t
+    iterateNodes :  Nat
+                 -> List (Tree1 s a)
+                 -> F1 s (RRBVector1 s a)
+    iterateNodes sh trees t =
+      let trees' # t := nodes' sh trees Lin t
+        in case trees' of
+             [tree]  =>
+               let treesize # t := treeSize sh tree t
+                 in (Root treesize sh tree) # t
+             trees'' =>
+               iterateNodes (up sh) (assert_smaller trees trees'') t
+
+||| Creates a vector of length n with every element set to x. O(log n)
+export
+replicate :  Nat
+          -> a
+          -> F1 s (RRBVector1 s a)
+replicate n x t =
+  case compare n 0 of
+    LT =>
+      Empty # t
+    EQ =>
+      Empty # t
+    GT =>
+      case compare n blocksize of
+        LT =>
+          let newarr # t := marray1 n x t
+            in Root n 0 (Leaf {lsize=n} (n ** newarr)) # t
+        EQ =>
+          let newarr # t := marray1 n x t
+            in Root n 0 (Leaf {lsize=n} (n ** newarr)) # t
+        GT =>
+          let size'       := integerToNat ((natToInteger $ minus n 1) .&. (natToInteger $ plus blockmask 1))
+              newarr1 # t := marray1 blocksize x t
+              newarr2 # t := marray1 size' x t
+              tree1       := Leaf {lsize=blocksize} (blocksize ** newarr1)
+              tree2       := Leaf {lsize=size'} (size' ** newarr2)
+            in iterateNodes blockshift
+                            tree1
+                            tree2
+                            t
+  where
+    iterateNodes :  (sh : Shift)
+                 -> (full : Tree1 s a)
+                 -> (rest : Tree1 s a)
+                 -> F1 s (RRBVector1 s a)
+    iterateNodes sh full rest t =
+      let subtreesm1   := (natToInteger $ minus n 1) `shiftR` sh
+          restsize     := integerToNat (subtreesm1 .&. (natToInteger blockmask))
+          mappend1 # t := marray1 restsize full t
+          mappend2 # t := marray1 1 rest t
+          rest'    # t := mappend mappend1 mappend2 t
+          rest''       := Balanced {bsize=plus restsize 1} ((plus restsize 1) ** rest')
+        in case compare subtreesm1 (natToInteger blocksize) of
+             LT =>
+               (Root n sh rest'') # t
+             EQ =>
+               let newarr # t := marray1 blocksize full t
+                   full'      := Balanced {bsize=blocksize} (blocksize ** newarr)
+                 in iterateNodes (up sh)
+                                 (assert_smaller full full')
+                                 (assert_smaller rest rest'')
+                                 t
+             GT =>
+               let newarr # t := marray1 blocksize full t
+                   full'      := Balanced {bsize=blocksize} (blocksize ** newarr)
+                 in iterateNodes (up sh)
+                                 (assert_smaller full full')
+                                 (assert_smaller rest rest'')
+                                 t
+
+--------------------------------------------------------------------------------
+--          Creating linear lists from linear RRB-Vectors
+--------------------------------------------------------------------------------
+
+private
+treeToList :  (n ** MArray s n (Tree1 s a))
+           -> F1 s (List a)
+treeToList (n ** arr) t =
+  go 0 n Lin t
+  where
+    go :  (m, x : Nat)
+       -> (sl : SnocList a)
+       -> {auto v : Ix x n}
+       -> F1 s (List a)
+    go m Z     sl t =
+      (sl <>> []) # t
+    go m (S j) sl t =
+      let j' # t := getIx arr j t
+        in case j' of
+             (Balanced (b ** arr'))     =>
+               let arr'' # t := assert_total $ treeToList (b ** arr') t
+                   sl'       := sl <>< arr''
+                 in go (S m) j sl' t
+             (Unbalanced (u ** arr') _) =>
+               let arr'' # t := assert_total $ treeToList (u ** arr') t
+                   sl'       := sl <>< arr''
+                 in go (S m) j sl' t
+             (Leaf (_ ** arr'))         =>
+               let arr'' # t := freeze arr' t
+                   arr'''    := toList arr''
+                   sl'       := sl <>< arr'''
+                 in go (S m) j sl' t
+
+||| Convert a vector to a list. O(n)
+export
+toList :  RRBVector1 s a
+       -> F1 s (List a)
+toList Empty                                t =
+  [] # t
+toList (Root _ _ (Balanced (b ** arr)))     t =
+  treeToList (b ** arr) t
+toList (Root _ _ (Unbalanced (u ** arr) _)) t =
+  treeToList (u ** arr) t
+toList (Root _ _ (Leaf (_ ** arr)))         t =
+  let arr' # t := freeze arr t
+    in toList arr' # t
+
+--------------------------------------------------------------------------------
+--          Query
+--------------------------------------------------------------------------------
+
+||| Is the vector empty? O(1)
+export
+null :  RRBVector1 s a
+     -> F1 s Bool
+null Empty t =
+  True # t
+null _     t =
+  False # t
+
+||| Return the size of a vector. O(1)
+export
+length :  RRBVector1 s a
+       -> F1 s Nat
+length Empty        t =
+  0 # t
+length (Root s _ _) t =
+  s # t
+
+--------------------------------------------------------------------------------
+--          Indexing
+--------------------------------------------------------------------------------
+
+||| The element at the index or Nothing if the index is out of range. O(log n)
+export
+lookup :  Nat
+       -> RRBVector1 s a
+       -> F1 s (Maybe a)
+lookup _ Empty               t = Nothing # t
+lookup i (Root size sh tree) t =
+  case compare i 0 of
+    LT =>
+      Nothing # t -- index out of range
+    GT =>
+      case compare i size of
+        EQ =>
+          Nothing # t -- index out of range
+        GT =>
+          Nothing # t -- index out of range
+        LT =>
+          let lookup' # t := lookupTree i sh tree t
+            in Just lookup' # t
+    EQ =>
+      case compare i size of
+        EQ =>
+          Nothing # t -- index out of range
+        GT =>
+          Nothing # t -- index out of range
+        LT =>
+          let lookup' # t := lookupTree i sh tree t
+            in Just lookup' # t
+  where
+    lookupTree :  Nat
+               -> Nat
+               -> Tree1 s a
+               -> F1 s a
+    lookupTree i sh (Balanced (_ ** arr))         t =
+      case tryNatToFin (radixIndex i sh) of
+        Nothing =>
+          (assert_total $ idris_crash "Data.RRBVector.lookup.lookupTree: can't convert Nat to Fin") # t
+        Just i' =>
+          let i'' # t := get arr i' t
+            in assert_total $ lookupTree i (down sh) i'' t
+    lookupTree i sh (Unbalanced (_ ** arr) sizes) t =
+      let (idx, subidx) := relaxedRadixIndex sizes i sh
+        in case tryNatToFin idx of
+             Nothing =>
+               (assert_total $ idris_crash "Data.RRBVector.lookup.lookupTree: can't convert Nat to Fin") # t
+             Just i' =>
+               let i'' # t := get arr i' t
+                 in assert_total $ lookupTree subidx (down sh) i'' t
+    lookupTree i _  (Leaf (_ ** arr))             t =
+      let i' = integerToNat ((natToInteger i) .&. (natToInteger blockmask))
+        in case tryNatToFin i' of
+             Nothing  =>
+               (assert_total $ idris_crash "Data.RRBVector.lookup.lookupTree: can't convert Nat to Fin") # t
+             Just i'' =>
+               let i''' # t := get arr i'' t
+                 in i''' # t
+
+||| The element at the index.
+||| Calls 'idris_crash' if the index is out of range. O(log n)
+export
+index :  Nat
+      -> RRBVector1 s a
+      -> F1 s a
+index i v t =
+  let lookup' # t := lookup i v t
+    in case lookup' of
+         Nothing       =>
+           (assert_total $ idris_crash "Data.RRBVector.index: index out of range") # t
+         Just lookup'' =>
+           lookup'' # t
+
+||| A flipped version of lookup. O(log n)
+export
+(!?) :  RRBVector1 s a
+     -> Nat
+     -> F1 s (Maybe a)
+(!?) t = flip lookup t
+
+||| A flipped version of index. O(log n)
+export
+(!!) :  RRBVector1 s a
+     -> Nat
+     -> F1 s a
+(!!) t = flip index t
+
+||| Update the element at the index with a new element.
+||| If the index is out of range, the original vector is returned. O(log n)
+export
+update :  Nat
+       -> a
+       -> RRBVector1 s a
+       -> F1 s (RRBVector1 s a)
+update _ _ Empty                 t = Empty # t
+update i x v@(Root size sh tree) t =
+  case compare i 0 of
+    LT =>
+      v # t -- index out of range
+    GT =>
+      case compare i size of
+        EQ =>
+          v # t -- index out of range
+        GT =>
+          v # t -- index out of range
+        LT =>
+          let update' # t := updateTree i sh tree t
+            in ( Root size
+                      sh
+                      update'
+               ) # t
+    EQ =>
+      case compare i size of
+        EQ =>
+          v # t -- index out of range
+        GT =>
+          v # t -- index out of range
+        LT =>
+          let update' # t := updateTree i sh tree t
+            in ( Root size
+                      sh
+                      update'
+               ) # t
+  where
+    updateTree :  Nat
+               -> Nat
+               -> Tree1 s a
+               -> F1 s (Tree1 s a)
+    updateTree i sh (Balanced (b ** arr))         t =
+      case tryNatToFin (radixIndex i sh) of
+        Nothing =>
+          (assert_total $ idris_crash "Data.RRBVector.update.updateTree: can't convert Nat to Fin") # t
+        Just i' =>
+          let newtree  # t := get arr i' t
+              newtree' # t := assert_total $ updateTree i (down sh) newtree t
+              ()       # t := set arr i' newtree' t
+            in (Balanced {bsize=b} (b ** arr)) # t
+    updateTree i sh (Unbalanced (u ** arr) sizes) t =
+      let (idx, subidx) := relaxedRadixIndex sizes i sh
+        in case tryNatToFin idx of
+             Nothing   =>
+               (assert_total $ idris_crash "Data.RRBVector.update.updateTree: can't convert Nat to Fin") # t
+             Just idx' =>
+               let newtree  # t := get arr idx' t
+                   newtree' # t := assert_total $ updateTree subidx (down sh) newtree t
+                   ()       # t := set arr idx' newtree' t
+                 in (Unbalanced (u ** arr) sizes) # t
+    updateTree i _  (Leaf (l ** arr))             t =
+      let i' = integerToNat ((natToInteger i) .&. (natToInteger blockmask))
+        in case tryNatToFin i' of
+             Nothing =>
+               (assert_total $ idris_crash "Data.RRBVector.update: can't convert Nat to Fin") # t
+             Just i'' =>
+               let () # t := set arr i'' x t
+                 in (Leaf {lsize=l} (l ** arr)) # t
+
+||| Adjust the element at the index by applying the function to it.
+||| If the index is out of range, the original vector is returned. O(log n)
+export
+adjust :  Nat
+       -> (a -> a)
+       -> RRBVector1 s a
+       -> F1 s (RRBVector1 s a)
+adjust _ _ Empty                 t = Empty # t
+adjust i f v@(Root size sh tree) t =
+  case compare i 0 of
+    LT =>
+      v # t -- index out of range
+    GT =>
+      case compare i size of
+        EQ =>
+          v # t -- index out of range
+        GT =>
+          v # t -- index out of range
+        LT =>
+          let adjust' # t := adjustTree i sh tree t
+            in ( Root size
+                      sh
+                      adjust'
+               ) # t
+    EQ =>
+      case compare i size of
+        EQ =>
+          v # t -- index out of range
+        GT =>
+          v # t -- index out of range
+        LT =>
+          let adjust' # t := adjustTree i sh tree t
+            in ( Root size
+                      sh
+                      adjust'
+               ) # t
+  where
+    adjustTree :  Nat
+               -> Nat
+               -> Tree1 s a
+               -> F1 s (Tree1 s a)
+    adjustTree i sh (Balanced (b ** arr))         t =
+      case tryNatToFin (radixIndex i sh) of
+        Nothing =>
+          (assert_total $ idris_crash "Data.RRBVector.adjust: can't convert Nat to Fin") # t
+        Just i' =>
+          let newtree  # t := get arr i' t
+              newtree' # t := assert_total $ adjustTree i (down sh) newtree t
+              ()       # t := set arr i' newtree' t
+            in (Balanced {bsize=b} (b ** arr)) # t
+    adjustTree i sh (Unbalanced (u ** arr) sizes) t =
+      let (idx, subidx) := relaxedRadixIndex sizes i sh
+        in case tryNatToFin idx of
+             Nothing   =>
+               (assert_total $ idris_crash "Data.RRBVector.adjust: can't convert Nat to Fin") # t
+             Just idx' =>
+               let newtree  # t := get arr idx' t
+                   newtree' # t := assert_total $ adjustTree subidx (down sh) newtree t
+                   ()       # t := set arr idx' newtree' t
+                 in (Unbalanced (u ** arr) sizes) # t
+    adjustTree i _  (Leaf (l ** arr))             t =
+      let i' = integerToNat ((natToInteger i) .&. (natToInteger blockmask))
+        in case tryNatToFin i' of
+             Nothing =>
+               (assert_total $ idris_crash "Data.RRBVector.adjust: can't convert Nat to Fin") # t
+             Just i'' =>
+               let () # t := modify arr i'' f t
+                 in (Leaf {lsize=l} (l ** arr)) # t
+
+private
+normalize :  RRBVector1 s a
+          -> F1 s (RRBVector1 s a)
+normalize v@(Root size sh (Balanced (b ** arr)))         t =
+  case compare b 1 of
+    LT =>
+      v # t
+    EQ =>
+      case tryNatToFin 0 of
+        Nothing   =>
+          (assert_total $ idris_crash "Data.RRBVector.normalize: can't convert Nat to Fin") # t
+        Just zero =>
+          let arr' # t := get arr zero t
+            in assert_total $ (normalize (Root size (down sh) arr') t)
+    GT =>
+      v # t
+normalize v@(Root size sh (Unbalanced (u ** arr) sizes)) t =
+  case compare u 1 of
+    LT =>
+      v # t
+    EQ =>
+      case tryNatToFin 0 of
+        Nothing   =>
+          (assert_total $ idris_crash "Data.RRBVector.normalize: can't convert Nat to Fin") # t
+        Just zero =>
+          let arr' # t := get arr zero t
+            in assert_total $ (normalize (Root size (down sh) arr') t)
+    GT =>
+      v # t
+normalize v                                                 t =
+  v # t
+
+||| The initial i is n - 1 (the index of the last element in the new tree).
+private
+takeTree :  Nat
+         -> Shift
+         -> Tree1 s a
+         -> F1 s (Tree1 s a)
+takeTree i sh (Balanced (b ** arr)) with (radixIndex i sh) | ((plus (radixIndex i sh) 1) <= b) proof eq
+  _ | i' | True  = \t =>
+    case tryNatToFin i' of
+      Nothing  =>
+        (assert_total $ idris_crash "Data.RRBVector1.takeTree: can't convert Nat to Fin") # t
+      Just i'' =>
+        let arr'     # t := mtake arr (plus (radixIndex i sh) 1) @{lteOpReflectsLTE _ _ eq} t
+            newtree  # t := get arr' i'' t
+            newtree' # t := assert_total $ takeTree i (down sh) newtree t
+            ()       # t := set arr' i'' newtree' t
+          in (Balanced {bsize=(plus (radixIndex i sh) 1)} ((plus (radixIndex i sh) 1) ** arr')) # t
+  _ | _  | False = \t =>
+    (assert_total $ idris_crash "Data.RRBVector1.takeTree: index out of bounds") # t
+takeTree i sh (Unbalanced (u ** arr) sizes) with (relaxedRadixIndex sizes i sh) | ((plus (fst (relaxedRadixIndex sizes i sh)) 1) <= u) proof eq
+  _ | (idx, subidx) | True  = \t =>
+    case tryNatToFin idx of
+      Nothing   =>
+        (assert_total $ idris_crash "Data.RRBVector1.takeTree: can't convert Nat to Fin") # t
+      Just idx' =>
+        let arr'      # t := mtake arr (plus (fst (relaxedRadixIndex sizes i sh)) 1) @{lteOpReflectsLTE _ _ eq} t
+            newtree   # t := get arr' idx' t
+            newtree'  # t := assert_total $ takeTree subidx (down sh) newtree t
+            ()        # t := set arr' idx' newtree' t
+            newtree'' # t := computeSizes sh arr' t
+          in newtree'' # t
+  _ | _             | False = \t =>
+    (assert_total $ idris_crash "Data.RRBVector1.takeTree: index out of bounds") # t
+takeTree i _ (Leaf (l ** arr)) with (integerToNat (((natToInteger i) .&. (natToInteger blockmask)) + 1) <= l) proof eq
+  _ | True  = \t =>
+    case ((integerToNat (((natToInteger i) .&. (natToInteger blockmask)) + 1)) <= l) of
+      True  =>
+        let arr' # t := mtake arr (integerToNat (((natToInteger i) .&. (natToInteger blockmask)) + 1)) @{lteOpReflectsLTE _ _ eq} t
+          in (Leaf {lsize=(integerToNat (((natToInteger i) .&. (natToInteger blockmask)) + 1))} ((integerToNat (((natToInteger i) .&. (natToInteger blockmask)) + 1)) ** arr')) # t
+      False =>
+        (assert_total $ idris_crash "Data.RRBVector1.takeTree: index out of bounds") # t
+  _ | False = \t =>
+    (assert_total $ idris_crash "Data.RRBVector1.takeTree: index out of bounds") # t
+
+private
+dropTree :  Nat
+         -> Shift
+         -> Tree1 s a
+         -> F1 s (Tree1 s a)
+dropTree n sh (Balanced (b ** arr))         t =
+  let idx := radixIndex n sh
+    in case tryNatToFin 0 of
+         Nothing   =>
+           (assert_total $ idris_crash "Data.RRBVector.dropTree: can't convert Nat to Fin") # t
+         Just zero =>
+           let arr'      # t := mdrop idx arr t
+               newtree   # t := get arr' zero t
+               newtree'  # t := assert_total $ dropTree n (down sh) newtree t
+               ()        # t := set arr' zero newtree' t
+               newtree'' # t := computeSizes sh arr' t
+             in newtree'' # t
+dropTree n sh (Unbalanced (u ** arr) sizes) t =
+  let (idx, subidx) := relaxedRadixIndex sizes n sh
+    in case tryNatToFin 0 of
+         Nothing   =>
+           (assert_total $ idris_crash "Data.RRBVector.dropTree: can't convert Nat to Fin") # t
+         Just zero =>
+           let arr'      # t := mdrop idx arr t
+               newtree   # t := get arr' zero t
+               newtree'  # t := assert_total $ dropTree subidx (down sh) newtree t
+               ()        # t := set arr' zero newtree' t
+               newtree'' # t := computeSizes sh arr' t
+             in newtree'' # t
+dropTree n _  (Leaf (l ** arr))             t =
+  let n'       := integerToNat ((natToInteger n) .&. (natToInteger blockmask))
+      arr' # t := mdrop n' arr t
+    in (Leaf {lsize=minus l n'} ((minus l n') ** arr')) # t
+
+||| The first i elements of the vector.
+||| If the vector contains less than or equal to i elements, the whole vector is returned. O(log n)
+export
+take :  Nat
+     -> RRBVector1 s a
+     -> F1 s (RRBVector1 s a)
+take _ Empty                 t = empty t
+take n v@(Root size sh tree) t =
+  case compare n 0 of
+    LT =>
+      empty t
+    EQ =>
+      empty t
+    GT =>
+      case compare n size of
+        LT =>
+          let tt # t := takeTree (minus n 1) sh tree t
+            in normalize (Root n sh tt) t
+        EQ =>
+          v # t
+        GT =>
+          v # t
+
+||| The vector without the first i elements.
+||| If the vector contains less than or equal to i elements, the empty vector is returned. O(log n)
+export
+drop :  Nat
+     -> RRBVector1 s a
+     -> F1 s (RRBVector1 s a)
+drop _ Empty                 t = empty t
+drop n v@(Root size sh tree) t =
+  case compare n 0 of
+    LT =>
+      v # t
+    EQ =>
+      v # t
+    GT =>
+      case compare n size of
+        LT =>
+          let dt # t := dropTree n sh tree t
+            in normalize (Root (size `minus` n) sh dt) t
+        EQ =>
+          empty t
+        GT =>
+          empty t
+
+||| Split the vector at the given index. O(log n)
+export
+splitAt :  Nat
+        -> RRBVector1 s a
+        -> F1 s (RRBVector1 s a, RRBVector1 s a)
+splitAt _ Empty                 t = (Empty, Empty) # t
+splitAt n v@(Root size sh tree) t =
+  case compare n 0 of
+    LT =>
+      (Empty, v) # t
+    EQ =>
+      (Empty, v) # t
+    GT =>
+      case compare n size of
+        LT =>
+          let dt    # t := dropTree n sh tree t
+              tt    # t := takeTree (minus n 1) sh tree t
+              left  # t := normalize (Root n sh tt) t
+              right # t := normalize (Root (size `minus` n) sh dt) t
+            in (left, right) # t
+        EQ =>
+          (v, Empty) # t
+        GT =>
+          (v, Empty) # t
+
+--------------------------------------------------------------------------------
+--          Deconstruction
+--------------------------------------------------------------------------------
+
+||| The first element and the vector without the first element, or 'Nothing' if the vector is empty. O(log n)
+export
+viewl :  RRBVector1 s a
+      -> F1 s (Maybe (a, RRBVector1 s a))
+viewl Empty             t = Nothing # t
+viewl v@(Root _ _ tree) t =
+  let tail # t := drop 1 v t
+      head # t := headTree tree t
+    in (Just (head, tail)) # t
+  where
+    headTree :  Tree1 s a
+             -> F1 s a
+    headTree (Balanced (_ ** arr))     t =
+      case tryNatToFin 0 of
+        Nothing   =>
+          (assert_total $ idris_crash "Data.RRBVector.viewl: can't convert Nat to Fin") # t
+        Just zero =>
+          let headtree # t := get arr zero t
+            in assert_total $ headTree headtree t
+    headTree (Unbalanced (_ ** arr) _) t =
+      case tryNatToFin 0 of
+        Nothing   =>
+          (assert_total $ idris_crash "Data.RRBVector.viewl: can't convert Nat to Fin") # t
+        Just zero =>
+          let headtree # t := get arr zero t
+            in assert_total $ headTree headtree t
+    headTree (Leaf (_ ** arr))         t =
+      case tryNatToFin 0 of
+        Nothing   =>
+          (assert_total $ idris_crash "Data.RRBVector.viewl: can't convert Nat to Fin") # t
+        Just zero =>
+          get arr zero t
+
+||| The vector without the last element and the last element, or 'Nothing' if the vector is empty. O(log n)
+export
+viewr :  RRBVector1 s a
+      -> F1 s (Maybe (RRBVector1 s a, a))
+viewr Empty                t = Nothing # t
+viewr v@(Root size _ tree) t =
+  let init # t := take (minus size 1) v t
+      last # t := lastTree tree t
+    in (Just (init, last)) # t
+  where
+    lastTree :  Tree1 s a
+             -> F1 s a
+    lastTree (Balanced (_ ** arr))     t =
+      case tryNatToFin (minus size 1) of
+        Nothing   =>
+          (assert_total $ idris_crash "Data.RRBVector.viewr: can't convert Nat to Fin") # t
+        Just last =>
+          let lasttree # t := get arr last t
+            in assert_total $ lastTree lasttree t
+    lastTree (Unbalanced (_ ** arr) _) t =
+      case tryNatToFin (minus size 1) of
+        Nothing   =>
+          (assert_total $ idris_crash "Data.RRBVector.viewr: can't convert Nat to Fin") # t
+        Just last =>
+          let lasttree # t := get arr last t
+            in assert_total $ lastTree lasttree t
+    lastTree (Leaf (_ ** arr))         t =
+      case tryNatToFin (minus size 1) of
+        Nothing   =>
+          (assert_total $ idris_crash "Data.RRBVector.viewr: can't convert Nat to Fin") # t
+        Just last =>
+          get arr last t
+
+--------------------------------------------------------------------------------
+--          Transformation
+--------------------------------------------------------------------------------
+
+private
+mapTree :  {n : Nat}
+        -> (F1 s a -> F1 s b)
+        -> (arr : MArray s n (Tree1 s a))
+        -> F1 s (MArray s n (Tree1 s b))
+mapTree f arr t =
+  let tmt # t := unsafeMArray1 n t
+    in go 0 n tmt t
+  where
+    go :  (m, x : Nat)
+       -> (arr' : MArray s n (Tree1 s b))
+       -> {auto v : Ix x n}
+       -> F1 s (MArray s n (Tree1 s b))
+    go m Z     arr' t =
+      arr' # t
+    go m (S j) arr' t =
+      let j' # t := getIx arr j t
+        in case j' of
+             (Balanced (b ** arr''))         =>
+               case tryNatToFin m of
+                 Nothing =>
+                   (assert_total $ idris_crash "Data.RRBVector.mapTree: can't convert Nat to Fin") # t
+                 Just m' =>
+                   let arr''' # t := assert_total $ mapTree f arr'' t
+                       arr''''    := Balanced {bsize=b} (b ** arr''')
+                       ()     # t := set arr' m' arr'''' t
+                     in go (S m) j arr' t
+             (Unbalanced (u ** arr'') sizes) =>
+               case tryNatToFin m of
+                 Nothing =>
+                   (assert_total $ idris_crash "Data.RRBVector.mapTree.go: can't convert Nat to Fin") # t
+                 Just m' =>
+                   let arr''' # t := assert_total $ mapTree f arr'' t
+                       arr''''    := Unbalanced (u ** arr''') sizes
+                       ()     # t := set arr' m' arr'''' t
+                     in go (S m) j arr' t
+             (Leaf (l ** arr''))             =>
+               case tryNatToFin m of
+                 Nothing =>
+                   (assert_total $ idris_crash "Data.RRBVector.mapTree.go: can't convert Nat to Fin") # t
+                 Just m' =>
+                   let arr''' # t := mmap f arr'' t
+                       arr''''    := Leaf {lsize=l} (l ** arr''')
+                       ()     # t := set arr' m' arr'''' t
+                     in go (S m) j arr' t
+
+||| Apply the function to every element. O(n)
+export
+map :  (F1 s a -> F1 s b)
+    -> RRBVector1 s a
+    -> F1 s (RRBVector1 s b)
+map _ Empty                                        t =
+  empty t
+map f (Root size sh (Balanced (b ** arr)))         t =
+  let arr' # t := mapTree f arr t
+      arr''    := Balanced {bsize=b} (b ** arr')
+    in (Root size sh arr'') # t
+map f (Root size sh (Unbalanced (u ** arr) sizes)) t =
+  let arr' # t := mapTree f arr t
+      arr''    := Unbalanced (u ** arr') sizes
+    in (Root size sh arr'') # t
+map f (Root size sh (Leaf (l ** arr)))             t =
+  let arr' # t := mmap f arr t
+      arr''    := Leaf {lsize=l} (l ** arr')
+    in (Root size sh arr'') # t
+
+--------------------------------------------------------------------------------
+--          Concatenation
+--------------------------------------------------------------------------------
+
+||| Create a new tree with shift sh.
+private
+newBranch :  a
+          -> Shift
+          -> F1 s (Tree1 s a)
+newBranch x 0  t =
+  let x' # t := Data.RRBVector1.Unsized.Internal.singleton x t
+    in (Leaf {lsize=1} (1 ** x')) # t
+newBranch x sh t =
+  let branch # t := assert_total $ newBranch x (down sh) t
+      x'     # t := Data.RRBVector1.Unsized.Internal.singleton' branch t
+    in (Balanced {bsize=1} (1 ** x')) # t
+
+||| Create a new tree with shift sh.
+private
+newBranch' :  Tree1 s a
+           -> Shift
+           -> F1 s (Tree1 s (Tree1 s a))
+newBranch' tree 0  t =
+  (assert_total $ idris_crash "Data.RRBVector1.newBranch': impossible zero shift with a (Tree1 s a).") # t
+newBranch' tree sh t =
+  let branch  # t := assert_total $ newBranch' tree (down sh) t
+      tree'   # t := Data.RRBVector1.Unsized.Internal.singleton' branch t
+    in (Balanced {bsize=1} (1 ** tree')) # t
+
+||| Add an element to the left end of the vector. O(log n)
+export
+(<|) :  a
+     -> RRBVector1 s a
+     -> F1 s (RRBVector1 s a)
+(x <| Empty)               t =
+  singleton x t
+(x <| (Root size sh tree)) t =
+  let sh' # t := insertshift t
+    in case compare sh' sh of
+         LT =>
+           let constree # t := consTree sh tree t
+             in (Root (plus size 1) sh constree) # t
+         EQ =>
+           let constree # t := consTree sh tree t
+             in (Root (plus size 1) sh constree) # t
+         GT =>
+           let newtree # t := newBranch x sh t
+               newlist     := [newtree, tree]
+               new     # t := unsafeMArray1 (length newlist) t
+               ()      # t := writeList new newlist t
+               new'    # t := computeSizes sh' new t
+             in (Root (plus size 1) sh' new') # t
+  where
+    -- compute the shift at which the new branch needs to be inserted (0 means there is space in the leaf)
+    -- the size is computed for efficient calculation of the shift in a balanced subtree
+    computeShift :  Nat
+                 -> Nat
+                 -> Nat
+                 -> Tree1 s a
+                 -> F1 s Nat
+    computeShift sz sh min (Balanced _)                  t =
+      -- sz - 1 is the index of the last element
+      let comp     := mult (log2 (minus sz 1) `div` blockshift) blockshift -- the shift of the root when normalizing
+          hishift  := case compare comp 0 of
+                        LT =>
+                          0
+                        EQ =>
+                          0
+                        GT =>
+                          comp
+          hi       := (natToInteger $ minus sz 1) `shiftR` hishift -- the length of the root node when normalizing minus 1
+          newshift := case compare hi (natToInteger blockmask) of
+                        LT =>
+                          hishift
+                        EQ =>
+                          plus hishift blockshift
+                        GT =>
+                          plus hishift blockshift
+        in case compare newshift sh of
+             LT =>
+               newshift # t
+             EQ =>
+               newshift # t
+             GT =>
+               min # t
+    computeShift _  sh min (Unbalanced (u ** arr) sizes) t =
+      case tryNatToFin 0 of
+        Nothing   =>
+          (assert_total $ idris_crash "Data.RRBVector1.(<|).computeShift.Unbalanced: can't convert Nat to Fin") # t
+        Just zero =>
+          let newtree # t := get arr zero t
+            in case tryNatToFin 0 of
+                 Nothing    =>
+                   (assert_total $ idris_crash "Data.RRBVector1.(<|).computeShift.Unbalanced: can't convert Nat to Fin") # t
+                 Just zero' =>
+                   let sz' := at sizes zero'
+                     in case compare u blocksize of
+                          LT =>
+                            assert_total $ computeShift sz' (down sh) sh newtree t
+                          EQ =>
+                            assert_total $ computeShift sz' (down sh) min newtree t
+                          GT =>
+                            assert_total $ computeShift sz' (down sh) min newtree t
+    computeShift _  _  min (Leaf (l ** _))               t =
+      case compare l blocksize of
+        LT =>
+          0 # t
+        EQ =>
+          min # t
+        GT =>
+          min # t
+    insertshift : F1 s Nat
+    insertshift t =
+      computeShift size sh (up sh) tree t
+    consTree :  Nat
+             -> Tree1 s a
+             -> F1 s (Tree1 s a)
+    consTree sh (Balanced (_ ** arr))     t =
+      let sh' # t := insertshift t
+        in case compare sh sh' of
+             LT =>
+               case tryNatToFin 0 of
+                 Nothing   =>
+                   (assert_total $ idris_crash "Data.RRBVector1.(<|).consTree.Balanced: can't convert Nat to Fin") # t
+                 Just zero =>
+                   let newtree   # t := get arr zero t
+                       newtree'  # t := assert_total $ consTree (down sh) newtree t
+                       ()        # t := set arr zero newtree' t
+                       newtree'' # t := computeSizes sh arr t
+                     in newtree'' # t
+             EQ =>
+               let newtree   # t := newBranch x (down sh) t
+                   arr'      # t := marray1 1 newtree t
+                   arr''     # t := mappend arr' arr t
+                   newtree'' # t := computeSizes sh arr'' t
+                 in newtree'' # t
+             GT =>
+               case tryNatToFin 0 of
+                 Nothing   =>
+                   (assert_total $ idris_crash "Data.RRBVector1.(<|).consTree.Balanced: can't convert Nat to Fin") # t
+                 Just zero =>
+                   let newtree   # t := get arr zero t
+                       newtree'  # t := assert_total $ consTree (down sh) newtree t
+                       ()        # t := set arr zero newtree' t
+                       newtree'' # t := computeSizes sh arr t
+                     in newtree'' # t
+    consTree sh (Unbalanced (_ ** arr) _) t =
+      let sh' # t := insertshift t
+        in case compare sh sh' of
+             LT =>
+               case tryNatToFin 0 of
+                 Nothing   =>
+                   (assert_total $ idris_crash "Data.RRBVector1.(<|).consTree.Unbalanced: can't convert Nat to Fin") # t
+                 Just zero =>
+                   let newtree   # t := get arr zero t
+                       newtree'  # t := assert_total $ consTree (down sh) newtree t
+                       ()        # t := set arr zero newtree' t
+                       newtree'' # t := computeSizes sh arr t
+                     in newtree'' # t
+             EQ =>
+               let newtree   # t := newBranch x (down sh) t
+                   arr'      # t := marray1 1 newtree t
+                   arr''     # t := mappend arr' arr t
+                   newtree'' # t := computeSizes sh arr'' t
+                 in newtree'' # t
+             GT =>
+               case tryNatToFin 0 of
+                 Nothing   =>
+                   (assert_total $ idris_crash "Data.RRBVector1.(<|).consTree.Unbalanced: can't convert Nat to Fin") # t
+                 Just zero =>
+                   let newtree   # t := get arr zero t
+                       newtree'  # t := assert_total $ consTree (down sh) newtree t
+                       ()        # t := set arr zero newtree' t
+                       newtree'' # t := computeSizes sh arr t
+                     in newtree'' # t
+    consTree _  (Leaf (l ** arr))         t =
+      let arr'  # t := marray1 1 x t
+          arr'' # t := mappend arr' arr t
+        in (Leaf {lsize=(S l)} ((S l) ** arr'')) # t
+
+||| Add an element to the right end of the vector. O(log n)
+export
+(|>) :  RRBVector1 s a
+     -> a
+     -> F1 s (RRBVector1 s a)
+(Empty |> x)             t =
+  singleton x t
+(Root size sh tree |> x) t =
+  let sh' # t := insertshift t
+    in case compare sh' sh of
+         LT =>
+           let snoctree # t := snocTree sh tree t
+             in (Root (plus size 1) sh snoctree) # t
+         EQ =>
+           let snoctree # t := snocTree sh tree t
+             in (Root (plus size 1) sh snoctree) # t
+         GT =>
+           let newtree # t := newBranch x sh t
+               newlist     := [tree, newtree]
+               new     # t := unsafeMArray1 (length newlist) t
+               ()      # t := writeList new newlist t
+               new'    # t := computeSizes sh' new t
+             in (Root (plus size 1) sh' new') # t
+  where
+    -- compute the shift at which the new branch needs to be inserted (0 means there is space in the leaf)
+    -- the size is computed for efficient calculation of the shift in a balanced subtree
+    computeShift :  Nat
+                 -> Nat
+                 -> Nat
+                 -> Tree1 s a
+                 -> F1 s Nat
+    computeShift sz sh min (Balanced _)                  t =
+      -- sz - 1 is the index of the last element
+      let newshift := mult (countTrailingZeros sz `div` blockshift) blockshift
+        in case compare newshift sh of
+             LT =>
+               newshift # t
+             EQ =>
+               newshift # t
+             GT =>
+               min # t
+    computeShift _  sh min (Unbalanced (u ** arr) sizes) t =
+      case tryNatToFin $ minus u 1 of
+        Nothing       =>
+          (assert_total $ idris_crash "Data.RRBVector1.(|>).computeShift.Unbalanced: can't convert Nat to Fin") # t
+        Just lastidx' =>
+          let newtree # t := get arr lastidx' t
+            in case tryNatToFin $ minus u 1 of
+                 Nothing       =>
+                   (assert_total $ idris_crash "Data.RRBVector1.(|>).computeShift.Unbalanced: can't convert Nat to Fin") # t
+                 Just lastidx' =>
+                   let sizes' := at sizes lastidx'
+                     in case tryNatToFin $ minus (minus u 1) 1 of
+                          Nothing    =>
+                            (assert_total $ idris_crash "Data.RRBVector1.(|>).computeShift.Unbalanced: can't convert Nat to Fin") # t
+                          Just lastidx'' =>
+                            let sizes''     := at sizes lastidx''
+                                sz'         := minus sizes' sizes''
+                              in case compare u blocksize of
+                                   LT =>
+                                     assert_total $ computeShift sz' (down sh) sh newtree t
+                                   EQ =>
+                                     assert_total $ computeShift sz' (down sh) min newtree t
+                                   GT =>
+                                     assert_total $ computeShift sz' (down sh) min newtree t
+    computeShift _  _  min (Leaf (l ** arr))             t =
+      case compare l blocksize of
+        LT =>
+          0 # t
+        EQ =>
+          min # t
+        GT =>
+          min # t
+    insertshift : F1 s Nat
+    insertshift t =
+      computeShift size sh (up sh) tree t
+    snocTree :  Nat
+             -> Tree1 s a
+             -> F1 s (Tree1 s a)
+    snocTree sh (Balanced (b ** arr))     t =
+      let sh' # t := insertshift t
+        in case compare sh sh' of
+             LT =>
+               case tryNatToFin $ minus b 1 of
+                 Nothing      =>
+                   (assert_total $ idris_crash "Data.RRBVector1.(|>).snocTree.Balanced: can't convert Nat to Fin") # t
+                 Just lastidx =>
+                   let newtree   # t := get arr lastidx t
+                       newtree'  # t := assert_total $ snocTree (down sh) newtree t
+                       ()        # t := set arr lastidx newtree' t
+                       in (Balanced {bsize=b} (b ** arr)) # t
+             EQ => -- the current subtree is fully balanced
+               let newtree   # t := newBranch x (down sh) t
+                   arr'      # t := marray1 1 newtree t
+                   arr''     # t := mappend arr' arr t
+                 in (Balanced {bsize=(S b)} ((S b) ** arr'')) # t
+             GT =>
+               case tryNatToFin $ minus b 1 of
+                 Nothing      =>
+                   (assert_total $ idris_crash "Data.RRBVector1.(|>).snocTree.Balanced: can't convert Nat to Fin") # t
+                 Just lastidx =>
+                   let newtree   # t := get arr lastidx t
+                       newtree'  # t := assert_total $ snocTree (down sh) newtree t
+                       ()        # t := set arr lastidx newtree' t
+                     in (Balanced {bsize=b} (b ** arr)) # t
+    snocTree sh (Unbalanced (u ** arr) sizes) t =
+      let sh' # t := insertshift t
+        in case compare sh sh' of
+             LT =>
+               case tryNatToFin $ minus u 1 of
+                 Nothing       =>
+                   (assert_total $ idris_crash "Data.RRBVector1.(|>).snocTree.Unbalanced: can't convert Nat to Fin") # t
+                 Just lastidxa =>
+                   let newtree  # t := get arr lastidxa t
+                       newtree' # t := assert_total $ snocTree (down sh) newtree t
+                       ()       # t := set arr lastidxa newtree' t
+                     in case tryNatToFin $ minus u 1 of
+                          Nothing       =>
+                            (assert_total $ idris_crash "Data.RRBVector1.(|>).snocTree.Unbalanced: can't convert Nat to Fin") # t
+                          Just lastidxs =>
+                            let lastsize := plus (at sizes lastidxs) 1
+                              in (Unbalanced (u ** arr)
+                                             (setAt lastidxs lastsize sizes)
+                                 ) # t
+             EQ =>
+                case tryNatToFin $ minus u 1 of
+                  Nothing      =>
+                    (assert_total $ idris_crash "Data.RRBVector1.(|>).snocTree.Unbalanced: can't convert Nat to Fin") # t
+                  Just lastidx =>
+                    let lastsize      := plus (at sizes lastidx) 1
+                        newtree   # t := newBranch x (down sh) t
+                        arr'      # t := marray1 1 newtree t
+                        arr''     # t := mappend arr arr' t
+                      in (Unbalanced ((plus u 1) ** arr'')
+                                     (append sizes (fill 1 lastsize))
+                         ) # t
+             GT =>
+               case tryNatToFin $ minus u 1 of
+                 Nothing       =>
+                   (assert_total $ idris_crash "Data.RRBVector1.(|>).snocTree.Unbalanced: can't convert Nat to Fin") # t
+                 Just lastidxa =>
+                   let newtree  # t := get arr lastidxa t
+                       newtree' # t := assert_total $ snocTree (down sh) newtree t
+                       ()       # t := set arr lastidxa newtree' t
+                     in case tryNatToFin $ minus u 1 of
+                          Nothing       =>
+                            (assert_total $ idris_crash "Data.RRBVector1.(|>).snocTree.Unbalanced: can't convert Nat to Fin") # t
+                          Just lastidxs =>
+                            let lastsize := plus (at sizes lastidxs) 1
+                              in (Unbalanced (u ** arr)
+                                             (setAt lastidxs lastsize sizes)
+                                 ) # t
+    snocTree _  (Leaf (l ** arr))         t =
+      let arr'  # t := marray1 1 x t
+          arr'' # t := mappend arr arr' t
+        in (Leaf {lsize=(plus l 1)} ((plus l 1) ** arr'')) # t
+
+||| Concatenates two vectors. O(log(max(n1,n2)))
+export
+(><) :  RRBVector1 s a
+     -> RRBVector1 s a
+     -> F1 s (RRBVector1 s a)
+(Empty                >< v)                    t =
+  v # t
+(v                    >< Empty)                t =
+  v # t
+(Root size1 sh1 tree1 >< Root size2 sh2 tree2) t =
+  let upmaxshift := case compare sh1 sh2 of
+                      LT =>
+                        up sh2
+                      EQ =>
+                        up sh1
+                      GT =>
+                        up sh1
+      (_ ** arr) # t := mergeTrees tree1 sh1 tree2 sh2 t
+      arr'       # t := computeSizes upmaxshift arr t
+      arr''          := Root (plus size1 size2) upmaxshift arr'
+    in normalize arr'' t
+  where
+    viewlArr :  {n : Nat}
+             -> MArray s n (Tree1 s a)
+             -> F1 s (Tree1 s a, MArray s (n `minus` 1) (Tree1 s a))
+    viewlArr arr t =
+      case tryNatToFin 0 of
+        Nothing   =>
+          (assert_total $ idris_crash "Data.RRBVector1.(><).viewlArr: can't convert Nat to Fin") # t
+        Just zero =>
+          let arr'  # t := get arr zero t
+              arr'' # t := mdrop 1 arr t
+            in (arr', arr'') # t
+    viewrArr :  {n : Nat}
+             -> MArray s n (Tree1 s a)
+             -> F1 s (MArray s (n `minus` 1) (Tree1 s a), Tree1 s a)
+    viewrArr arr with ((minus n 1) <= n) proof eq
+      _ | True  = \t =>
+        case tryNatToFin $ minus n 1 of
+          Nothing   =>
+            (assert_total $ idris_crash "Data.RRBVector.(><).viewrArr: can't convert Nat to Fin") # t
+          Just last =>
+            let arr'  # t := get arr last t
+                arr'' # t := mtake arr (minus n 1) @{lteOpReflectsLTE _ _ eq} t
+              in (arr'', arr') # t
+      _ | False = \t =>
+        (assert_total $ idris_crash "Data.RRBVector1.(><).viewrArr: index out of bounds") # t
+    takeArr :  {n : Nat}
+            -> {blocksize : Nat}
+            -> MArray s n a
+            -> F1 s (MArray s blocksize a)
+    takeArr arr with (blocksize <= n) proof eq
+      _ | True  = \t =>
+        mtake arr blocksize @{lteOpReflectsLTE _ _ eq} t
+      _ | False = \t =>
+        (assert_total $ idris_crash "Data.RRBVector1.(><).takeArr: index out of bounds") # t
+    mergeRebalanceInternalGo' :  (x : Nat)
+                              -> (sh : Shift)
+                              -> MArray s n (Tree1 s a)
+                              -> (o ** MArray s o (Tree1 s a))
+                              -> (p ** MArray s p (Tree1 s a))
+                              -> (q ** MArray s q (Tree1 s a))
+                              -> {auto v : Ix x n}
+                              -> F1 s ((o' ** MArray s o' (Tree1 s a)), (p' ** MArray s p' (Tree1 s a)), (q' ** MArray s q' (Tree1 s a)))
+    mergeRebalanceInternalGo' Z      _  _    (o ** newnode'') (p ** newsubtree'') (q ** newroot'') t =
+      ((o ** newnode''), (p ** newsubtree''), (q ** newroot'')) # t
+    mergeRebalanceInternalGo' (S j') sh arr' (o ** newnode'') (p ** newsubtree'') (q ** newroot'') t =
+      case o == blocksize of
+        True  =>
+          case p == blocksize of
+            True  =>
+              let newnode'''       # t := computeSizes (down sh) newnode'' t
+                  newnode''''      # t := marray1 1 newnode''' t
+                  newsubtree'''    # t := mappend newsubtree'' newnode'''' t
+                  newnode'''''     # t := unsafeMArray1 0 t
+                  newsubtree''''   # t := computeSizes sh newsubtree''' t
+                  newsubtree'''''  # t := marray1 1 newsubtree'''' t
+                  newroot'''       # t := mappend newroot'' newsubtree''''' t
+                  newsubtree'''''' # t := unsafeMArray1 0 t
+                  j''              # t := getIx arr' j' t
+                  newnode''''''    # t := marray1 1 j'' t
+                  newnode'''''''   # t := mappend newnode''''' newnode'''''' t
+                in mergeRebalanceInternalGo' j' sh arr' (1 ** newnode''''''') (0  ** newsubtree'''''') ((plus q 1) ** newroot''') t
+            False =>
+              let newnode'''       # t := computeSizes (down sh) newnode'' t
+                  newnode''''      # t := marray1 1 newnode''' t
+                  newsubtree'''    # t := mappend newsubtree'' newnode'''' t
+                  newnode'''''     # t := unsafeMArray1 0 t
+                  j''              # t := getIx arr' j' t
+                  newnode''''''    # t := marray1 1 j'' t
+                  newnode'''''''   # t := mappend newnode''''' newnode'''''' t
+                in mergeRebalanceInternalGo' j' sh arr' (1 ** newnode''''''') ((plus p 1) ** newsubtree''') (q ** newroot'') t
+        False =>
+          let j''           # t := getIx arr' j' t
+              newnode'''    # t := marray1 1 j'' t
+              newnode''''   # t := mappend newnode'' newnode''' t
+            in mergeRebalanceInternalGo' j' sh arr' ((plus o 1) ** newnode'''') (p ** newsubtree'') (q ** newroot'') t
+    mergeRebalanceInternalGo :  (x : Nat)
+                             -> (sh : Shift)
+                             -> MArray s n (Tree1 s a)
+                             -> (o ** MArray s o (Tree1 s a))
+                             -> (p ** MArray s p (Tree1 s a))
+                             -> (q ** MArray s q (Tree1 s a))
+                             -> {auto v : Ix x n}
+                             -> F1 s (r ** MArray s r (Tree1 s a))
+    mergeRebalanceInternalGo Z     sh arr (_ ** newnode') (_ ** newsubtree') (q ** newroot') t =
+      let newnode''      # t := computeSizes (down sh) newnode' t
+          newnode'''     # t := marray1 1 newnode'' t
+          newsubtree''   # t := mappend newsubtree' newnode''' t
+          newsubtree'''  # t := computeSizes sh newsubtree'' t
+          newsubtree'''' # t := marray1 1 newsubtree''' t
+          newroot''      # t := mappend newroot' newsubtree'''' t
+        in ((plus q 1) ** newroot'') # t
+    mergeRebalanceInternalGo (S j) sh arr (o ** newnode') (p ** newsubtree') (q ** newroot') t =
+      let j'  # t := getIx arr j t
+          j''     := treeToArray j'
+        in case j'' of
+             Left  (b ** arr') =>
+               let ((o' ** newnode''), (p' ** newsubtree''), (q' ** newroot'')) # t := mergeRebalanceInternalGo' b sh arr' (o ** newnode') (p ** newsubtree') (q ** newroot') t
+                 in mergeRebalanceInternalGo j sh arr (o' ** newnode'') (p' ** newsubtree'') (q' ** newroot'') t
+             Right (u ** arr') =>
+               let ((o' ** newnode''), (p' ** newsubtree''), (q' ** newroot'')) # t := mergeRebalanceInternalGo' u sh arr' (o ** newnode') (p ** newsubtree') (q ** newroot') t
+                 in mergeRebalanceInternalGo j sh arr (o' ** newnode'') (p' ** newsubtree'') (q' ** newroot'') t
+    mergeRebalanceInternal' :  {n : Nat}
+                            -> Shift
+                            -> MArray s n (Tree1 s a)
+                            -> F1 s (r ** MArray s r (Tree1 s a))
+    mergeRebalanceInternal' sh lcr t =
+      let newnode        # t := unsafeMArray1 0 t
+          newsubtree     # t := unsafeMArray1 0 t
+          newroot        # t := unsafeMArray1 0 t
+        in mergeRebalanceInternalGo n sh lcr (0 ** newnode) (0 ** newsubtree) (0 ** newroot) t
+    mergeRebalance' :  {n : Nat}
+                    -> {m : Nat}
+                    -> {o : Nat}
+                    -> Shift
+                    -> MArray s n (Tree1 s a)
+                    -> MArray s m (Tree1 s a)
+                    -> MArray s o (Tree1 s a)
+                    -> F1 s (r ** MArray s r (Tree1 s a))
+    mergeRebalance' sh left center right t =
+      let centerright     # t := mappend center right t
+          leftcenterright # t := mappend left centerright t
+        in mergeRebalanceInternal' sh
+                                   leftcenterright
+                                   t
+    mergeRebalanceInternalGo''' :  (x : Nat)
+                                -> (sh : Shift)
+                                -> MArray s n a
+                                -> (o ** MArray s o a)
+                                -> (p ** MArray s p (Tree1 s a))
+                                -> (q ** MArray s q (Tree1 s a))
+                                -> {auto v : Ix x n}
+                                -> F1 s ((o' ** MArray s o' a), (p' ** MArray s p' (Tree1 s a)), (q' ** MArray s q' (Tree1 s a)))
+    mergeRebalanceInternalGo''' Z      _  _    (o ** newnode'') (p ** newsubtree'') (q ** newroot'') t =
+      ((o ** newnode''), (p ** newsubtree''), (q ** newroot'')) # t
+    mergeRebalanceInternalGo''' (S j') sh arr' (o ** newnode'') (p ** newsubtree'') (q ** newroot'') t =
+      case o == blocksize of
+        True  =>
+          case p == blocksize of
+            True  =>
+              let newnode'''           := Leaf {lsize=0} (o ** newnode'')
+                  newnode''''      # t := marray1 1 newnode''' t
+                  newsubtree'''    # t := mappend newsubtree'' newnode'''' t
+                  newnode'''''     # t := unsafeMArray1 0 t
+                  newsubtree''''   # t := computeSizes sh newsubtree''' t
+                  newsubtree'''''  # t := marray1 1 newsubtree'''' t
+                  newroot'''       # t := mappend newroot'' newsubtree''''' t
+                  newsubtree'''''' # t := unsafeMArray1 0 t
+                  j''              # t := getIx arr' j' t
+                  newnode''''''    # t := marray1 1 j'' t
+                  newnode'''''''   # t := mappend newnode''''' newnode'''''' t
+                in mergeRebalanceInternalGo''' j' sh arr' (1 ** newnode''''''') (0  ** newsubtree'''''') ((plus q 1) ** newroot''') t
+            False =>
+              let newnode'''           := Leaf {lsize=0} (o ** newnode'')
+                  newnode''''      # t := marray1 1 newnode''' t
+                  newsubtree'''    # t := mappend newsubtree'' newnode'''' t
+                  newnode'''''     # t := unsafeMArray1 0 t
+                  j''              # t := getIx arr' j' t
+                  newnode''''''    # t := marray1 1 j'' t
+                  newnode'''''''   # t := mappend newnode''''' newnode'''''' t
+                in mergeRebalanceInternalGo''' j' sh arr' (1 ** newnode''''''') ((plus p 1) ** newsubtree''') (q ** newroot'') t
+        False =>
+          let j''           # t := getIx arr' j' t
+              newnode'''    # t := marray1 1 j'' t
+              newnode''''   # t := mappend newnode'' newnode''' t
+            in mergeRebalanceInternalGo''' j' sh arr' ((plus o 1) ** newnode'''') (p ** newsubtree'') (q ** newroot'') t
+    mergeRebalanceInternalGo'' :  (x : Nat)
+                               -> (sh : Shift)
+                               -> MArray s n (Tree1 s a)
+                               -> (o ** MArray s o a)
+                               -> (p ** MArray s p (Tree1 s a))
+                               -> (q ** MArray s q (Tree1 s a))
+                               -> {auto v : Ix x n}
+                               -> F1 s (r ** MArray s r (Tree1 s a))
+    mergeRebalanceInternalGo'' Z     sh arr (o ** newnode') (_ ** newsubtree') (q ** newroot') t =
+      let newnode''          := Leaf {lsize=o} (o ** newnode')
+          newnode'''     # t := marray1 1 newnode'' t
+          newsubtree''   # t := mappend newsubtree' newnode''' t
+          newsubtree'''  # t := computeSizes sh newsubtree'' t
+          newsubtree'''' # t := marray1 1 newsubtree''' t
+          newroot''      # t := mappend newroot' newsubtree'''' t
+        in ((plus q 1) ** newroot'') # t
+    mergeRebalanceInternalGo'' (S j) sh arr (o ** newnode') (p ** newsubtree') (q ** newroot') t =
+      let j'                                                           # t := getIx arr j t
+          (l ** arr')                                                      := treeToArray' j'
+          ((o' ** newnode''), (p' ** newsubtree''), (q' ** newroot'')) # t := mergeRebalanceInternalGo''' l sh arr' (o ** newnode') (p ** newsubtree') (q ** newroot') t
+        in mergeRebalanceInternalGo'' j sh arr (o' ** newnode'') (p' ** newsubtree'') (q' ** newroot'') t
+    mergeRebalanceInternal'' :  {n : Nat}
+                             -> Shift
+                             -> MArray s n (Tree1 s a)
+                             -> F1 s (r ** MArray s r (Tree1 s a))
+    mergeRebalanceInternal'' sh lcr t =
+      let newnode        # t := unsafeMArray1 0 t
+          newsubtree     # t := unsafeMArray1 0 t
+          newroot        # t := unsafeMArray1 0 t
+        in mergeRebalanceInternalGo'' n sh lcr (0 ** newnode) (0 ** newsubtree) (0 ** newroot) t
+    mergeRebalance'' :  {n : Nat}
+                     -> {m : Nat}
+                     -> {o : Nat}
+                     -> Shift
+                     -> MArray s n (Tree1 s a)
+                     -> MArray s m (Tree1 s a)
+                     -> MArray s o (Tree1 s a)
+                     -> F1 s (r ** MArray s r (Tree1 s a))
+    mergeRebalance'' sh left center right t =
+      let centerright     # t := mappend center right t
+          leftcenterright # t := mappend left centerright t
+        in mergeRebalanceInternal'' sh
+                                    leftcenterright
+                                    t
+    mergeRebalance :  {n : Nat}
+                   -> {m : Nat}
+                   -> {o : Nat}
+                   -> Shift
+                   -> MArray s n (Tree1 s a)
+                   -> MArray s m (Tree1 s a)
+                   -> MArray s o (Tree1 s a)
+                   -> F1 s (r ** MArray s r (Tree1 s a))
+    mergeRebalance sh left center right t =
+      case compare sh blockshift of
+        LT =>
+          mergeRebalance' sh left center right t
+        EQ =>
+          mergeRebalance'' sh left center right t
+        GT =>
+          mergeRebalance' sh left center right t
+    mergeTrees :  Tree1 s a
+               -> Nat
+               -> Tree1 s a
+               -> Nat
+               -> F1 s (r ** MArray s r (Tree1 s a))
+    mergeTrees tree1@(Leaf (l1 ** arr1)) _   tree2@(Leaf (l2 ** arr2)) _   t =
+      case compare l1 blocksize of
+        LT =>
+          let arr' # t := mappend arr1 arr2 t
+            in case compare (plus l1 l2) blocksize of
+                 LT =>
+                   let newtree   := Leaf {lsize=(plus l1 l2)} ((plus l1 l2) ** arr')
+                       arr'' # t := singleton' newtree t
+                     in (1 ** arr'') # t
+                 EQ =>
+                   let newtree   := Leaf {lsize=(plus l1 l2)} ((plus l1 l2) ** arr')
+                       arr'' # t := singleton' newtree t
+                     in (1 ** arr'') # t
+                 GT =>
+                   let left  # t := takeArr arr' t
+                       right # t := mdrop blocksize arr' t
+                       lefttree  := Leaf {lsize=blocksize} (blocksize ** left)
+                       righttree := Leaf {lsize=(minus (plus l1 l2) blocksize)} ((minus (plus l1 l2) blocksize) ** right)
+                       newlist   := [lefttree, righttree]
+                       arr'' # t := unsafeMArray1 (length newlist) t
+                       ()    # t := writeList arr'' newlist t
+                     in ((length newlist) ** arr'') # t
+        EQ =>
+          let newlist   := [tree1, tree2]
+              arr'' # t := unsafeMArray1 (length newlist) t
+              ()    # t := writeList arr'' newlist t
+            in ((length newlist) ** arr'') # t
+        GT =>
+          let arr' # t := mappend arr1 arr2 t
+            in case compare (plus l1 l2) blocksize of
+                 LT =>
+                   let newtree   := Leaf {lsize=(plus l1 l2)} ((plus l1 l2) ** arr')
+                       arr'' # t := singleton' newtree t
+                     in (1 ** arr'') # t
+                 EQ =>
+                   let newtree   := Leaf {lsize=(plus l1 l2)} ((plus l1 l2) ** arr')
+                       arr'' # t := singleton' newtree t
+                     in (1 ** arr'') # t
+                 GT =>
+                   let left  # t := takeArr arr' t
+                       right # t := mdrop blocksize arr' t
+                       lefttree  := Leaf {lsize=blocksize} (blocksize ** left)
+                       righttree := Leaf {lsize=(minus (plus l1 l2) blocksize)} ((minus (plus l1 l2) blocksize) ** right)
+                       newlist   := [lefttree, righttree]
+                       arr'' # t := unsafeMArray1 (length newlist) t
+                       ()    # t := writeList arr'' newlist t
+                     in ((length newlist) ** arr'') # t
+    mergeTrees tree1                     sh1 tree2                     sh2 t =
+      case compare sh1 sh2 of
+        LT =>
+          let right := treeToArray tree2
+            in case right of
+                 Left  (_ ** arr) =>
+                   let (righthead, righttail) # t := viewlArr arr t
+                       (_ ** merged)          # t := assert_total $ mergeTrees tree1 sh1 righthead (down sh2) t
+                       emptyarr               # t := unsafeMArray1 0 t
+                     in mergeRebalance sh2 emptyarr merged righttail t
+                 Right (_ ** arr) =>
+                   let (righthead, righttail) # t := viewlArr arr t
+                       (_ ** merged)          # t := assert_total $ mergeTrees tree1 sh1 righthead (down sh2) t
+                       emptyarr               # t := unsafeMArray1 0 t
+                     in mergeRebalance sh2 emptyarr merged righttail t
+        EQ =>
+          let left := treeToArray tree1
+            in case left of
+                 Left  (_ ** arr) =>
+                   let right := treeToArray tree2
+                     in case right of
+                          Left  (_ ** arr') =>
+                            let (leftinit, leftlast)   # t := viewrArr arr t
+                                (righthead, righttail) # t := viewlArr arr' t
+                                (_ ** merged)          # t := assert_total $ mergeTrees leftlast (down sh1) righthead (down sh2) t
+                              in mergeRebalance sh1 leftinit merged righttail t
+                          Right (_ ** arr') =>
+                            let (leftinit, leftlast)   # t := viewrArr arr t
+                                (righthead, righttail) # t := viewlArr arr' t
+                                (_ ** merged)          # t := assert_total $ mergeTrees leftlast (down sh1) righthead (down sh2) t
+                              in mergeRebalance sh1 leftinit merged righttail t
+                 Right (_ ** arr) =>
+                   let right := treeToArray tree2
+                     in case right of
+                          Left  (_ ** arr') =>
+                            let (leftinit, leftlast)   # t := viewrArr arr t
+                                (righthead, righttail) # t := viewlArr arr' t
+                                (_ ** merged)          # t := assert_total $ mergeTrees leftlast (down sh1) righthead (down sh2) t
+                              in mergeRebalance sh1 leftinit merged righttail t
+                          Right (_ ** arr') =>
+                            let (leftinit, leftlast)   # t := viewrArr arr t
+                                (righthead, righttail) # t := viewlArr arr' t
+                                (_ ** merged)          # t := assert_total $ mergeTrees leftlast (down sh1) righthead (down sh2) t
+                              in mergeRebalance sh1 leftinit merged righttail t
+        GT =>
+          let left := treeToArray tree1
+            in case left of
+                 Left  (_ ** arr) =>
+                   let (leftinit, leftlast) # t := viewrArr arr t
+                       (_ ** merged)        # t := assert_total $ mergeTrees leftlast (down sh1) tree2 sh2 t
+                       emptyarr             # t := unsafeMArray1 0 t
+                     in mergeRebalance sh1 leftinit merged emptyarr t
+                 Right (_ ** arr) =>
+                   let (leftinit, leftlast) # t := viewrArr arr t
+                       (_ ** merged)        # t := assert_total $ mergeTrees leftlast (down sh1) tree2 sh2 t
+                       emptyarr             # t := unsafeMArray1 0 t
+                     in mergeRebalance sh1 leftinit merged emptyarr t
+
+||| Insert an element at the given index, shifting the rest of the vector over.
+||| If the index is negative, add the element to the left end of the vector.
+||| If the index is bigger than or equal to the length of the vector, add the element to the right end of the vector. O(log n)
+export
+insertAt :  Nat
+         -> a
+         -> RRBVector1 s a
+         -> F1 s (RRBVector1 s a)
+insertAt i x v t =
+  let (left, right) # t := Data.RRBVector1.Unsized.splitAt i v t
+      left'         # t := ((|>) left x) t
+    in (><) left' right t
+
+||| Delete the element at the given index.
+||| If the index is out of range, return the original vector. O(log n)
+export
+deleteAt :  Nat
+         -> RRBVector1 s a
+         -> F1 s (RRBVector1 s a)
+deleteAt i v t =
+  let (left, right) # t := Data.RRBVector1.Unsized.splitAt (plus i 1) v t
+      left'         # t := take i left t
+    in (><) left' right t

--- a/src/Data/RRBVector1/Sized.idr
+++ b/src/Data/RRBVector1/Sized.idr
@@ -1171,14 +1171,16 @@ export
 
 ||| Concatenates two vectors. O(log(max(n1,n2)))
 export
-(><) :  RRBVector1 s a
-     -> RRBVector1 s a
-     -> F1 s (RRBVector1 s a)
-(Empty                >< v)                    t =
-  v # t
-(v                    >< Empty)                t =
-  v # t
-(Root size1 sh1 tree1 >< Root size2 sh2 tree2) t =
+(><) :  {n1 : Nat}
+     -> {n2 : Nat}
+     -> RRBVector1 s n1 a
+     -> RRBVector1 s n2 a
+     -> F1 s (n' ** RRBVector1 s n' a)
+(Empty          >< v)              t =
+  (n2 ** v) # t
+(v              >< Empty)          t =
+  (n1 ** v) # t
+(Root sh1 tree1 >< Root sh2 tree2) t =
   let upmaxshift := case compare sh1 sh2 of
                       LT =>
                         up sh2
@@ -1188,8 +1190,9 @@ export
                         up sh1
       (_ ** arr) # t := mergeTrees tree1 sh1 tree2 sh2 t
       arr'       # t := computeSizes upmaxshift arr t
-      arr''          := Root (plus size1 size2) upmaxshift arr'
-    in normalize arr'' t
+      arr''          := Root upmaxshift arr'
+      arr'''     # t := normalize arr'' t
+    in ((plus n1 n2) ** arr''') #  t
   where
     viewlArr :  {n : Nat}
              -> MArray s n (Tree1 s a)
@@ -1530,22 +1533,24 @@ export
 ||| If the index is negative, add the element to the left end of the vector.
 ||| If the index is bigger than or equal to the length of the vector, add the element to the right end of the vector. O(log n)
 export
-insertAt :  Nat
+insertAt :  {n : Nat}
+         -> Nat
          -> a
-         -> RRBVector1 s a
-         -> F1 s (RRBVector1 s a)
+         -> RRBVector1 s n a
+         -> F1 s (n' ** RRBVector1 s n' a)
 insertAt i x v t =
-  let (left, right) # t := Data.RRBVector1.Unsized.splitAt i v t
-      left'         # t := ((|>) left x) t
+  let ((tt ** left), (dt ** right)) # t := Data.RRBVector1.Sized.splitAt i v t
+      (l  ** left')                 # t := ((|>) left x) t
     in (><) left' right t
 
 ||| Delete the element at the given index.
 ||| If the index is out of range, return the original vector. O(log n)
 export
-deleteAt :  Nat
-         -> RRBVector1 s a
-         -> F1 s (RRBVector1 s a)
+deleteAt :  {n : Nat}
+         -> Nat
+         -> RRBVector1 s n a
+         -> F1 s (n' ** RRBVector1 s n' a)
 deleteAt i v t =
-  let (left, right) # t := Data.RRBVector1.Unsized.splitAt (plus i 1) v t
-      left'         # t := take i left t
+  let ((tt ** left), (dt ** right)) # t := Data.RRBVector1.Sized.splitAt (plus i 1) v t
+      (l' ** left')                 # t := take i left t
     in (><) left' right t

--- a/src/Data/RRBVector1/Sized.idr
+++ b/src/Data/RRBVector1/Sized.idr
@@ -675,7 +675,7 @@ splitAt i v@(Root sh tree) t =
     GT =>
       case compare i n of
         LT =>
-          let (dt ** right) # t := drop i v t 
+          let (dt ** right) # t := drop i v t
               (tt ** left)  # t := take i v t
             in ((tt ** left), (dt ** right)) # t
         EQ =>

--- a/src/Data/RRBVector1/Sized.idr
+++ b/src/Data/RRBVector1/Sized.idr
@@ -73,16 +73,15 @@ singleton x t =
 
 ||| Create a new vector from a list. O(n)
 export
-fromList :  List a
-         -> F1 s (RRBVector1 s a)
+fromList :  (xs : List a)
+         -> F1 s (RRBVector1 s (length xs) a)
 fromList []  t = empty t
 fromList [x] t = singleton x t
 fromList xs  t =
   let trees # t := nodes xs Lin t
     in case trees of
          [tree] =>
-           let treesize # t := treeSize 0 tree t
-             in (Root treesize 0 tree) # t
+           (Root 0 tree) # t
          xs'    =>
            assert_smaller xs (iterateNodes blockshift xs' t)
   where
@@ -127,21 +126,20 @@ fromList xs  t =
         (assert_total $ idris_crash "Data.RRBVector1.fromList.nodes': index out of bounds") # t
     iterateNodes :  Nat
                  -> List (Tree1 s a)
-                 -> F1 s (RRBVector1 s a)
+                 -> F1 s (RRBVector1 s n a)
     iterateNodes sh trees t =
       let trees' # t := nodes' sh trees Lin t
         in case trees' of
              [tree]  =>
-               let treesize # t := treeSize sh tree t
-                 in (Root treesize sh tree) # t
+               (Root sh tree) # t
              trees'' =>
                iterateNodes (up sh) (assert_smaller trees trees'') t
 
 ||| Creates a vector of length n with every element set to x. O(log n)
 export
-replicate :  Nat
+replicate :  (n : Nat)
           -> a
-          -> F1 s (RRBVector1 s a)
+          -> F1 s (RRBVector1 s n a)
 replicate n x t =
   case compare n 0 of
     LT =>
@@ -152,10 +150,10 @@ replicate n x t =
       case compare n blocksize of
         LT =>
           let newarr # t := marray1 n x t
-            in Root n 0 (Leaf {lsize=n} (n ** newarr)) # t
+            in Root 0 (Leaf {lsize=n} (n ** newarr)) # t
         EQ =>
           let newarr # t := marray1 n x t
-            in Root n 0 (Leaf {lsize=n} (n ** newarr)) # t
+            in Root 0 (Leaf {lsize=n} (n ** newarr)) # t
         GT =>
           let size'       := integerToNat ((natToInteger $ minus n 1) .&. (natToInteger $ plus blockmask 1))
               newarr1 # t := marray1 blocksize x t
@@ -170,7 +168,7 @@ replicate n x t =
     iterateNodes :  (sh : Shift)
                  -> (full : Tree1 s a)
                  -> (rest : Tree1 s a)
-                 -> F1 s (RRBVector1 s a)
+                 -> F1 s (RRBVector1 s n a)
     iterateNodes sh full rest t =
       let subtreesm1   := (natToInteger $ minus n 1) `shiftR` sh
           restsize     := integerToNat (subtreesm1 .&. (natToInteger blockmask))
@@ -180,7 +178,7 @@ replicate n x t =
           rest''       := Balanced {bsize=plus restsize 1} ((plus restsize 1) ** rest')
         in case compare subtreesm1 (natToInteger blocksize) of
              LT =>
-               (Root n sh rest'') # t
+               (Root sh rest'') # t
              EQ =>
                let newarr # t := marray1 blocksize full t
                    full'      := Balanced {bsize=blocksize} (blocksize ** newarr)
@@ -231,15 +229,15 @@ treeToList (n ** arr) t =
 
 ||| Convert a vector to a list. O(n)
 export
-toList :  RRBVector1 s a
+toList :  RRBVector1 s n a
        -> F1 s (List a)
-toList Empty                                t =
+toList Empty                              t =
   [] # t
-toList (Root _ _ (Balanced (b ** arr)))     t =
+toList (Root _ (Balanced (b ** arr)))     t =
   treeToList (b ** arr) t
-toList (Root _ _ (Unbalanced (u ** arr) _)) t =
+toList (Root _ (Unbalanced (u ** arr) _)) t =
   treeToList (u ** arr) t
-toList (Root _ _ (Leaf (_ ** arr)))         t =
+toList (Root _ (Leaf (_ ** arr)))         t =
   let arr' # t := freeze arr t
     in toList arr' # t
 
@@ -249,7 +247,7 @@ toList (Root _ _ (Leaf (_ ** arr)))         t =
 
 ||| Is the vector empty? O(1)
 export
-null :  RRBVector1 s a
+null :  RRBVector1 s n a
      -> F1 s Bool
 null Empty t =
   True # t
@@ -258,12 +256,11 @@ null _     t =
 
 ||| Return the size of a vector. O(1)
 export
-length :  RRBVector1 s a
+length :  {n : Nat}
+       -> RRBVector1 s n a
        -> F1 s Nat
-length Empty        t =
-  0 # t
-length (Root s _ _) t =
-  s # t
+length _ t =
+  n # t
 
 --------------------------------------------------------------------------------
 --          Indexing
@@ -271,16 +268,18 @@ length (Root s _ _) t =
 
 ||| The element at the index or Nothing if the index is out of range. O(log n)
 export
-lookup :  Nat
-       -> RRBVector1 s a
+lookup :  {n : Nat}
+       -> Nat
+       -> RRBVector1 s n a
        -> F1 s (Maybe a)
-lookup _ Empty               t = Nothing # t
-lookup i (Root size sh tree) t =
+lookup _ Empty          t =
+  Nothing # t
+lookup i (Root sh tree) t =
   case compare i 0 of
     LT =>
       Nothing # t -- index out of range
     GT =>
-      case compare i size of
+      case compare i n of
         EQ =>
           Nothing # t -- index out of range
         GT =>
@@ -289,7 +288,7 @@ lookup i (Root size sh tree) t =
           let lookup' # t := lookupTree i sh tree t
             in Just lookup' # t
     EQ =>
-      case compare i size of
+      case compare i n of
         EQ =>
           Nothing # t -- index out of range
         GT =>
@@ -329,8 +328,9 @@ lookup i (Root size sh tree) t =
 ||| The element at the index.
 ||| Calls 'idris_crash' if the index is out of range. O(log n)
 export
-index :  Nat
-      -> RRBVector1 s a
+index :  {n : Nat}
+      -> Nat
+      -> RRBVector1 s n a
       -> F1 s a
 index i v t =
   let lookup' # t := lookup i v t
@@ -342,52 +342,56 @@ index i v t =
 
 ||| A flipped version of lookup. O(log n)
 export
-(!?) :  RRBVector1 s a
+(!?) :  {n : Nat}
+     -> RRBVector1 s n a
      -> Nat
      -> F1 s (Maybe a)
-(!?) t = flip lookup t
+(!?) t =
+  flip lookup t
 
 ||| A flipped version of index. O(log n)
 export
-(!!) :  RRBVector1 s a
+(!!) :  {n : Nat}
+     -> RRBVector1 s n a
      -> Nat
      -> F1 s a
-(!!) t = flip index t
+(!!) t =
+  flip index t
 
 ||| Update the element at the index with a new element.
 ||| If the index is out of range, the original vector is returned. O(log n)
 export
-update :  Nat
+update :  {n : Nat}
+       -> Nat
        -> a
-       -> RRBVector1 s a
-       -> F1 s (RRBVector1 s a)
-update _ _ Empty                 t = Empty # t
-update i x v@(Root size sh tree) t =
+       -> RRBVector1 s n a
+       -> F1 s (RRBVector1 s n a)
+update _ _ Empty            t =
+  Empty # t
+update i x v@(Root sh tree) t =
   case compare i 0 of
     LT =>
       v # t -- index out of range
     GT =>
-      case compare i size of
+      case compare i n of
         EQ =>
           v # t -- index out of range
         GT =>
           v # t -- index out of range
         LT =>
           let update' # t := updateTree i sh tree t
-            in ( Root size
-                      sh
+            in ( Root sh
                       update'
                ) # t
     EQ =>
-      case compare i size of
+      case compare i n of
         EQ =>
           v # t -- index out of range
         GT =>
           v # t -- index out of range
         LT =>
           let update' # t := updateTree i sh tree t
-            in ( Root size
-                      sh
+            in ( Root sh
                       update'
                ) # t
   where
@@ -426,37 +430,37 @@ update i x v@(Root size sh tree) t =
 ||| Adjust the element at the index by applying the function to it.
 ||| If the index is out of range, the original vector is returned. O(log n)
 export
-adjust :  Nat
+adjust :  {n : Nat}
+       -> Nat
        -> (a -> a)
-       -> RRBVector1 s a
-       -> F1 s (RRBVector1 s a)
-adjust _ _ Empty                 t = Empty # t
-adjust i f v@(Root size sh tree) t =
+       -> RRBVector1 s n a
+       -> F1 s (RRBVector1 s n a)
+adjust _ _ Empty            t =
+  Empty # t
+adjust i f v@(Root sh tree) t =
   case compare i 0 of
     LT =>
       v # t -- index out of range
     GT =>
-      case compare i size of
+      case compare i n of
         EQ =>
           v # t -- index out of range
         GT =>
           v # t -- index out of range
         LT =>
           let adjust' # t := adjustTree i sh tree t
-            in ( Root size
-                      sh
+            in ( Root sh
                       adjust'
                ) # t
     EQ =>
-      case compare i size of
+      case compare i n of
         EQ =>
           v # t -- index out of range
         GT =>
           v # t -- index out of range
         LT =>
           let adjust' # t := adjustTree i sh tree t
-            in ( Root size
-                      sh
+            in ( Root sh
                       adjust'
                ) # t
   where
@@ -493,9 +497,9 @@ adjust i f v@(Root size sh tree) t =
                  in (Leaf {lsize=l} (l ** arr)) # t
 
 private
-normalize :  RRBVector1 s a
-          -> F1 s (RRBVector1 s a)
-normalize v@(Root size sh (Balanced (b ** arr)))         t =
+normalize :  RRBVector1 s n a
+          -> F1 s (RRBVector1 s n a)
+normalize v@(Root sh (Balanced (b ** arr)))         t =
   case compare b 1 of
     LT =>
       v # t
@@ -505,10 +509,10 @@ normalize v@(Root size sh (Balanced (b ** arr)))         t =
           (assert_total $ idris_crash "Data.RRBVector.normalize: can't convert Nat to Fin") # t
         Just zero =>
           let arr' # t := get arr zero t
-            in assert_total $ (normalize (Root size (down sh) arr') t)
+            in assert_total $ (normalize (Root (down sh) arr') t)
     GT =>
       v # t
-normalize v@(Root size sh (Unbalanced (u ** arr) sizes)) t =
+normalize v@(Root sh (Unbalanced (u ** arr) sizes)) t =
   case compare u 1 of
     LT =>
       v # t
@@ -518,10 +522,10 @@ normalize v@(Root size sh (Unbalanced (u ** arr) sizes)) t =
           (assert_total $ idris_crash "Data.RRBVector.normalize: can't convert Nat to Fin") # t
         Just zero =>
           let arr' # t := get arr zero t
-            in assert_total $ (normalize (Root size (down sh) arr') t)
+            in assert_total $ (normalize (Root (down sh) arr') t)
     GT =>
       v # t
-normalize v                                                 t =
+normalize v                                         t =
   v # t
 
 ||| The initial i is n - 1 (the index of the last element in the new tree).
@@ -605,73 +609,79 @@ dropTree n _  (Leaf (l ** arr))             t =
 ||| The first i elements of the vector.
 ||| If the vector contains less than or equal to i elements, the whole vector is returned. O(log n)
 export
-take :  Nat
-     -> RRBVector1 s a
-     -> F1 s (RRBVector1 s a)
-take _ Empty                 t = empty t
-take n v@(Root size sh tree) t =
-  case compare n 0 of
+take :  {n : Nat}
+     -> Nat
+     -> RRBVector1 s n a
+     -> F1 s (n' ** RRBVector1 s n' a)
+take _ Empty            t =
+  (0 ** Empty) # t
+take i v@(Root sh tree) t =
+  case compare i 0 of
     LT =>
-      empty t
+      (0 ** Empty) # t
     EQ =>
-      empty t
+      (0 ** Empty) # t
     GT =>
-      case compare n size of
+      case compare i n of
         LT =>
-          let tt # t := takeTree (minus n 1) sh tree t
-            in normalize (Root n sh tt) t
+          let tt  # t := takeTree (minus i 1) sh tree t
+              tt' # t := normalize (Root sh tt) t
+            in (i ** tt') # t
         EQ =>
-          v # t
+          (n ** v) # t
         GT =>
-          v # t
+          (n ** v) # t
 
 ||| The vector without the first i elements.
 ||| If the vector contains less than or equal to i elements, the empty vector is returned. O(log n)
 export
-drop :  Nat
-     -> RRBVector1 s a
-     -> F1 s (RRBVector1 s a)
-drop _ Empty                 t = empty t
-drop n v@(Root size sh tree) t =
-  case compare n 0 of
+drop :  {n : Nat}
+     -> Nat
+     -> RRBVector1 s n a
+     -> F1 s (n' ** RRBVector1 s n' a)
+drop _ Empty            t =
+  (0 ** Empty) # t
+drop i v@(Root sh tree) t =
+  case compare i 0 of
     LT =>
-      v # t
+      (n ** v) # t
     EQ =>
-      v # t
+      (n ** v) # t
     GT =>
-      case compare n size of
+      case compare i n of
         LT =>
-          let dt # t := dropTree n sh tree t
-            in normalize (Root (size `minus` n) sh dt) t
+          let dt  # t := dropTree i sh tree t
+              dt' # t := normalize (Root sh dt) t
+            in (i ** dt') # t
         EQ =>
-          empty t
+          (0 ** Empty) # t
         GT =>
-          empty t
+          (0 ** Empty) # t
 
 ||| Split the vector at the given index. O(log n)
 export
-splitAt :  Nat
-        -> RRBVector1 s a
-        -> F1 s (RRBVector1 s a, RRBVector1 s a)
-splitAt _ Empty                 t = (Empty, Empty) # t
-splitAt n v@(Root size sh tree) t =
-  case compare n 0 of
+splitAt :  {n : Nat}
+        -> Nat
+        -> RRBVector1 s n a
+        -> F1 s ((n' ** RRBVector1 s n' a), (n'' ** RRBVector1 s n'' a))
+splitAt _ Empty            t =
+  ((0 ** Empty), (0 ** Empty)) # t
+splitAt i v@(Root sh tree) t =
+  case compare i 0 of
     LT =>
-      (Empty, v) # t
+      ((0 ** Empty), (n ** v)) # t
     EQ =>
-      (Empty, v) # t
+      ((0 ** Empty), (n ** v)) # t
     GT =>
-      case compare n size of
+      case compare i n of
         LT =>
-          let dt    # t := dropTree n sh tree t
-              tt    # t := takeTree (minus n 1) sh tree t
-              left  # t := normalize (Root n sh tt) t
-              right # t := normalize (Root (size `minus` n) sh dt) t
-            in (left, right) # t
+          let (dt ** right) # t := drop i v t 
+              (tt ** left)  # t := take i v t
+            in ((tt ** left), (dt ** right)) # t
         EQ =>
-          (v, Empty) # t
+          ((n ** v), (0 ** Empty)) # t
         GT =>
-          (v, Empty) # t
+          ((n ** v), (0 ** Empty)) # t
 
 --------------------------------------------------------------------------------
 --          Deconstruction
@@ -679,13 +689,15 @@ splitAt n v@(Root size sh tree) t =
 
 ||| The first element and the vector without the first element, or 'Nothing' if the vector is empty. O(log n)
 export
-viewl :  RRBVector1 s a
-      -> F1 s (Maybe (a, RRBVector1 s a))
-viewl Empty             t = Nothing # t
-viewl v@(Root _ _ tree) t =
-  let tail # t := drop 1 v t
-      head # t := headTree tree t
-    in (Just (head, tail)) # t
+viewl :  {n : Nat}
+      -> RRBVector1 s n a
+      -> F1 s (n' ** Maybe (a, RRBVector1 s n' a))
+viewl Empty           t =
+  (0 ** Nothing) # t
+viewl v@(Root _ tree) t =
+  let (dt ** tail) # t := drop 1 v t
+      head         # t := headTree tree t
+    in (dt ** Just (head, tail)) # t
   where
     headTree :  Tree1 s a
              -> F1 s a
@@ -712,32 +724,34 @@ viewl v@(Root _ _ tree) t =
 
 ||| The vector without the last element and the last element, or 'Nothing' if the vector is empty. O(log n)
 export
-viewr :  RRBVector1 s a
-      -> F1 s (Maybe (RRBVector1 s a, a))
-viewr Empty                t = Nothing # t
-viewr v@(Root size _ tree) t =
-  let init # t := take (minus size 1) v t
-      last # t := lastTree tree t
-    in (Just (init, last)) # t
+viewr :  {n : Nat}
+      -> RRBVector1 s n a
+      -> F1 s (n' ** Maybe (RRBVector1 s n' a, a))
+viewr Empty           t =
+  (0 ** Nothing) # t
+viewr v@(Root _ tree) t =
+  let (tt ** init) # t := take (minus n 1) v t
+      last         # t := lastTree tree t
+    in (tt ** Just (init, last)) # t
   where
     lastTree :  Tree1 s a
              -> F1 s a
     lastTree (Balanced (_ ** arr))     t =
-      case tryNatToFin (minus size 1) of
+      case tryNatToFin (minus n 1) of
         Nothing   =>
           (assert_total $ idris_crash "Data.RRBVector.viewr: can't convert Nat to Fin") # t
         Just last =>
           let lasttree # t := get arr last t
             in assert_total $ lastTree lasttree t
     lastTree (Unbalanced (_ ** arr) _) t =
-      case tryNatToFin (minus size 1) of
+      case tryNatToFin (minus n 1) of
         Nothing   =>
           (assert_total $ idris_crash "Data.RRBVector.viewr: can't convert Nat to Fin") # t
         Just last =>
           let lasttree # t := get arr last t
             in assert_total $ lastTree lasttree t
     lastTree (Leaf (_ ** arr))         t =
-      case tryNatToFin (minus size 1) of
+      case tryNatToFin (minus n 1) of
         Nothing   =>
           (assert_total $ idris_crash "Data.RRBVector.viewr: can't convert Nat to Fin") # t
         Just last =>
@@ -795,23 +809,24 @@ mapTree f arr t =
 
 ||| Apply the function to every element. O(n)
 export
-map :  (F1 s a -> F1 s b)
-    -> RRBVector1 s a
-    -> F1 s (RRBVector1 s b)
-map _ Empty                                        t =
-  empty t
-map f (Root size sh (Balanced (b ** arr)))         t =
+map :  {n : Nat}
+    -> (F1 s a -> F1 s b)
+    -> RRBVector1 s n a
+    -> F1 s (n' ** RRBVector1 s n' b)
+map _ Empty                                   t =
+  (0 ** Empty) # t
+map f (Root sh (Balanced (b ** arr)))         t =
   let arr' # t := mapTree f arr t
       arr''    := Balanced {bsize=b} (b ** arr')
-    in (Root size sh arr'') # t
-map f (Root size sh (Unbalanced (u ** arr) sizes)) t =
+    in (n ** Root sh arr'') # t
+map f (Root sh (Unbalanced (u ** arr) sizes)) t =
   let arr' # t := mapTree f arr t
       arr''    := Unbalanced (u ** arr') sizes
-    in (Root size sh arr'') # t
-map f (Root size sh (Leaf (l ** arr)))             t =
+    in (n ** Root sh arr'') # t
+map f (Root sh (Leaf (l ** arr)))             t =
   let arr' # t := mmap f arr t
       arr''    := Leaf {lsize=l} (l ** arr')
-    in (Root size sh arr'') # t
+    in (n ** Root sh arr'') # t
 
 --------------------------------------------------------------------------------
 --          Concatenation
@@ -823,11 +838,11 @@ newBranch :  a
           -> Shift
           -> F1 s (Tree1 s a)
 newBranch x 0  t =
-  let x' # t := Data.RRBVector1.Unsized.Internal.singleton x t
+  let x' # t := Data.RRBVector1.Sized.Internal.singleton x t
     in (Leaf {lsize=1} (1 ** x')) # t
 newBranch x sh t =
   let branch # t := assert_total $ newBranch x (down sh) t
-      x'     # t := Data.RRBVector1.Unsized.Internal.singleton' branch t
+      x'     # t := Data.RRBVector1.Sized.Internal.singleton' branch t
     in (Balanced {bsize=1} (1 ** x')) # t
 
 ||| Create a new tree with shift sh.
@@ -839,32 +854,34 @@ newBranch' tree 0  t =
   (assert_total $ idris_crash "Data.RRBVector1.newBranch': impossible zero shift with a (Tree1 s a).") # t
 newBranch' tree sh t =
   let branch  # t := assert_total $ newBranch' tree (down sh) t
-      tree'   # t := Data.RRBVector1.Unsized.Internal.singleton' branch t
+      tree'   # t := Data.RRBVector1.Sized.Internal.singleton' branch t
     in (Balanced {bsize=1} (1 ** tree')) # t
 
 ||| Add an element to the left end of the vector. O(log n)
 export
-(<|) :  a
-     -> RRBVector1 s a
-     -> F1 s (RRBVector1 s a)
-(x <| Empty)               t =
-  singleton x t
-(x <| (Root size sh tree)) t =
+(<|) :  {n : Nat}
+     -> a
+     -> RRBVector1 s n a
+     -> F1 s (n' ** RRBVector1 s n' a)
+(x <| Empty)          t =
+  let s # t := Data.RRBVector1.Sized.singleton x t
+    in (1 ** s) # t
+(x <| (Root sh tree)) t =
   let sh' # t := insertshift t
     in case compare sh' sh of
          LT =>
            let constree # t := consTree sh tree t
-             in (Root (plus size 1) sh constree) # t
+             in ((plus n 1) ** Root sh constree) # t
          EQ =>
            let constree # t := consTree sh tree t
-             in (Root (plus size 1) sh constree) # t
+             in ((plus n 1) ** Root sh constree) # t
          GT =>
            let newtree # t := newBranch x sh t
                newlist     := [newtree, tree]
                new     # t := unsafeMArray1 (length newlist) t
                ()      # t := writeList new newlist t
                new'    # t := computeSizes sh' new t
-             in (Root (plus size 1) sh' new') # t
+             in ((plus n 1) ** Root sh' new') # t
   where
     -- compute the shift at which the new branch needs to be inserted (0 means there is space in the leaf)
     -- the size is computed for efficient calculation of the shift in a balanced subtree
@@ -926,7 +943,7 @@ export
           min # t
     insertshift : F1 s Nat
     insertshift t =
-      computeShift size sh (up sh) tree t
+      computeShift n sh (up sh) tree t
     consTree :  Nat
              -> Tree1 s a
              -> F1 s (Tree1 s a)
@@ -995,27 +1012,29 @@ export
 
 ||| Add an element to the right end of the vector. O(log n)
 export
-(|>) :  RRBVector1 s a
+(|>) :  {n : Nat}
+     -> RRBVector1 s n a
      -> a
-     -> F1 s (RRBVector1 s a)
-(Empty |> x)             t =
-  singleton x t
-(Root size sh tree |> x) t =
+     -> F1 s (n' ** RRBVector1 s n' a)
+(Empty |> x)        t =
+  let s # t := Data.RRBVector1.Sized.singleton x t
+    in (1 ** s) # t
+(Root sh tree |> x) t =
   let sh' # t := insertshift t
     in case compare sh' sh of
          LT =>
            let snoctree # t := snocTree sh tree t
-             in (Root (plus size 1) sh snoctree) # t
+             in ((plus n 1) ** Root sh snoctree) # t
          EQ =>
            let snoctree # t := snocTree sh tree t
-             in (Root (plus size 1) sh snoctree) # t
+             in ((plus n 1) ** Root sh snoctree) # t
          GT =>
            let newtree # t := newBranch x sh t
                newlist     := [tree, newtree]
                new     # t := unsafeMArray1 (length newlist) t
                ()      # t := writeList new newlist t
                new'    # t := computeSizes sh' new t
-             in (Root (plus size 1) sh' new') # t
+             in ((plus n 1) ** Root sh' new') # t
   where
     -- compute the shift at which the new branch needs to be inserted (0 means there is space in the leaf)
     -- the size is computed for efficient calculation of the shift in a balanced subtree
@@ -1068,7 +1087,7 @@ export
           min # t
     insertshift : F1 s Nat
     insertshift t =
-      computeShift size sh (up sh) tree t
+      computeShift n sh (up sh) tree t
     snocTree :  Nat
              -> Tree1 s a
              -> F1 s (Tree1 s a)

--- a/src/Data/RRBVector1/Sized/Internal.idr
+++ b/src/Data/RRBVector1/Sized/Internal.idr
@@ -1,5 +1,5 @@
 ||| Linear RRB Vector Internals
-module Data.RRBVector1.Internal
+module Data.RRBVector1.Sized.Internal
 
 import Data.Array.Core
 import Data.Array.Indexed
@@ -318,12 +318,11 @@ log2 x =
 --          Linear RRB Vectors
 --------------------------------------------------------------------------------
 
-||| A linear relaxed radix balanced vector (RRB-Vector).
+||| A linear relaxed radix balanced vector (RRBVector1).
 ||| It supports fast indexing, iteration, concatenation and splitting.
 public export
-data RRBVector1 : (s : Type) -> Type -> Type where
-  Root :  Nat   -- size
-       -> Shift -- shift (blockshift * height)
-       -> Tree1 s a
-       -> RRBVector1 s a
-  Empty : RRBVector1 s a
+data RRBVector1 : (s : Type) -> (n : Nat) -> Type -> Type where
+  Root  :  Shift -- shift (blockshift * height)
+        -> Tree1 s a
+        -> RRBVector1 s n a
+  Empty : RRBVector1 s n a

--- a/src/Data/RRBVector1/Unsized.idr
+++ b/src/Data/RRBVector1/Unsized.idr
@@ -1,7 +1,7 @@
 ||| Linear Relaxed Radix Balanced Vectors (RRBVector1)
-module Data.RRBVector1
+module Data.RRBVector1.Unsized
 
-import public Data.RRBVector1.Internal
+import public Data.RRBVector1.Unsized.Internal
 
 import Data.Array.Core
 import Data.Array.Index
@@ -823,11 +823,11 @@ newBranch :  a
           -> Shift
           -> F1 s (Tree1 s a)
 newBranch x 0  t =
-  let x' # t := Data.RRBVector1.Internal.singleton x t
+  let x' # t := Data.RRBVector1.Unsized.Internal.singleton x t
     in (Leaf {lsize=1} (1 ** x')) # t
 newBranch x sh t =
   let branch # t := assert_total $ newBranch x (down sh) t
-      x'     # t := Data.RRBVector1.Internal.singleton' branch t
+      x'     # t := Data.RRBVector1.Unsized.Internal.singleton' branch t
     in (Balanced {bsize=1} (1 ** x')) # t
 
 ||| Create a new tree with shift sh.
@@ -839,7 +839,7 @@ newBranch' tree 0  t =
   (assert_total $ idris_crash "Data.RRBVector1.newBranch': impossible zero shift with a (Tree1 s a).") # t
 newBranch' tree sh t =
   let branch  # t := assert_total $ newBranch' tree (down sh) t
-      tree'   # t := Data.RRBVector1.Internal.singleton' branch t
+      tree'   # t := Data.RRBVector1.Unsized.Internal.singleton' branch t
     in (Balanced {bsize=1} (1 ** tree')) # t
 
 ||| Add an element to the left end of the vector. O(log n)
@@ -1516,7 +1516,7 @@ insertAt :  Nat
          -> RRBVector1 s a
          -> F1 s (RRBVector1 s a)
 insertAt i x v t =
-  let (left, right) # t := Data.RRBVector1.splitAt i v t
+  let (left, right) # t := Data.RRBVector1.Unsized.splitAt i v t
       left'         # t := ((|>) left x) t
     in (><) left' right t
 
@@ -1527,6 +1527,6 @@ deleteAt :  Nat
          -> RRBVector1 s a
          -> F1 s (RRBVector1 s a)
 deleteAt i v t =
-  let (left, right) # t := Data.RRBVector1.splitAt (plus i 1) v t
+  let (left, right) # t := Data.RRBVector1.Unsized.splitAt (plus i 1) v t
       left'         # t := take i left t
     in (><) left' right t

--- a/src/Data/RRBVector1/Unsized/Internal.idr
+++ b/src/Data/RRBVector1/Unsized/Internal.idr
@@ -1,0 +1,329 @@
+||| Linear RRB Vector Internals
+module Data.RRBVector1.Unsized.Internal
+
+import Data.Array.Core
+import Data.Array.Indexed
+import Data.Array.Mutable
+import Data.Bits
+import Data.List
+import Data.Linear.Ref1
+import Data.Linear.Token
+import Data.Nat
+import Data.String
+import Derive.Prelude
+
+%default total
+%hide Data.Vect.Quantifiers.All.get
+%language ElabReflection
+
+--------------------------------------------------------------------------------
+--          Internal Utility
+--------------------------------------------------------------------------------
+
+||| Convenience interface for bitSize that doesn't use an implicit parameter.
+private
+bitSizeOf :  (ty : Type)
+          -> FiniteBits ty
+          => Nat
+bitSizeOf ty = bitSize {a = ty}
+
+--------------------------------------------------------------------------------
+--          Internals
+--------------------------------------------------------------------------------
+
+public export
+Shift : Type
+Shift = Nat
+
+||| The number of bits used per level.
+export
+blockshift : Shift
+blockshift = 4
+
+||| The maximum size of a block.
+export
+blocksize : Nat
+blocksize = integerToNat $ 1 `shiftL` blockshift
+
+||| The mask used to extract the index into the array.
+export
+blockmask : Nat
+blockmask = minus blocksize 1
+
+export
+up :  Shift
+   -> Shift
+up sh = plus sh blockshift
+
+export
+down :  Shift
+     -> Shift
+down sh = minus sh blockshift
+
+export
+radixIndex :  Nat
+           -> Shift
+           -> Nat
+radixIndex i sh = integerToNat ((natToInteger i) `shiftR` sh .&. (natToInteger blockmask))
+
+export
+relaxedRadixIndex :  {n : Nat}
+                  -> IArray n Nat
+                  -> Nat
+                  -> Shift
+                  -> (Nat, Nat)
+relaxedRadixIndex sizes i sh =
+  let guess  = radixIndex i sh -- guess <= idx
+      idx    = loop sizes guess
+      subIdx = case idx == 0 of
+                 True  =>
+                   i
+                 False =>
+                   let idx' = case tryNatToFin $ minus idx 1 of
+                                Nothing    =>
+                                  assert_total $ idris_crash "Data.RRBVector1.Internal.relaxedRadixIndex: index out of bounds"
+                                Just idx'' =>
+                                  idx''
+                     in minus i (at sizes idx')
+    in (idx, subIdx)
+  where
+    loop :  IArray n Nat
+         -> Nat
+         -> Nat
+    loop sizes idx =
+      let current = case tryNatToFin idx of
+                      Nothing       =>
+                        assert_total $ idris_crash "Data.RRBVector1.Internal.relaxedRadixIndex.loop: index out of bounds"
+                      Just idx' =>
+                        at sizes idx' -- idx will always be in range for a well-formed tree
+        in case i < current of
+             True  =>
+               idx
+             False =>
+               assert_total $ loop sizes (plus idx 1)
+
+--------------------------------------------------------------------------------
+--          Internal Tree Representation
+--------------------------------------------------------------------------------
+
+||| A linear internal tree representation.
+public export
+data Tree1 : (s : Type) -> Type -> Type where
+  Balanced   : {bsize : Nat} -> (bsize ** MArray s bsize (Tree1 s a)) -> Tree1 s a
+  Unbalanced : {usize : Nat} -> (usize ** MArray s usize (Tree1 s a)) -> IArray usize Nat -> Tree1 s a
+  Leaf       : {lsize : Nat} -> (lsize ** MArray s lsize a) -> Tree1 s a
+
+--------------------------------------------------------------------------------
+--          Tree Utilities
+--------------------------------------------------------------------------------
+
+export
+singleton :  a
+          -> F1 s (MArray s 1 a)
+singleton x t =
+  marray1 1 x t
+
+export
+singleton' :  Tree1 s a
+           -> F1 s (MArray s 1 (Tree1 s a))
+singleton' tree t =
+  marray1 1 tree t
+
+export
+treeToArray :  Tree1 s a
+            -> Either (bsize ** MArray s bsize (Tree1 s a))
+                      (usize ** MArray s usize (Tree1 s a))
+treeToArray (Balanced   arr)   =
+  Left arr
+treeToArray (Unbalanced arr _) =
+  Right arr
+treeToArray (Leaf       _)     =
+  assert_total $ idris_crash "Data.RRBVector1.Internal.treeToArray: leaf"
+
+export
+treeToArray' :  Tree1 s a
+             -> (lsize ** MArray s lsize a)
+treeToArray' (Balanced _)     =
+  assert_total $ idris_crash "Data.RRBVector1.Internal.treeToArray': balanced"
+treeToArray' (Unbalanced _ _) =
+  assert_total $ idris_crash "Data.RRBVector1.Internal.treeToArray': unbalanced"
+treeToArray' (Leaf arr)       =
+  arr
+
+export
+treeBalanced :  Tree1 s a
+             -> Bool
+treeBalanced (Balanced   _)   =
+  True
+treeBalanced (Unbalanced _ _) =
+  False
+treeBalanced (Leaf       _ )  =
+  True
+
+||| Computes the size of a tree with shift.
+export
+treeSize :  Shift
+         -> Tree1 s a
+         -> F1 s Nat
+treeSize t =
+  go 0 t
+  where
+    go :  Shift
+       -> Shift
+       -> Tree1 s a
+       -> F1 s Nat
+    go acc _  (Leaf       (l ** arr))       t =
+      plus acc l # t
+    go acc _  (Unbalanced (u ** arr) sizes) t =
+      let i := tryNatToFin $ minus u 1
+        in case i of
+             Nothing =>
+               (assert_total $ idris_crash "Data.RRBVector1.Internal.treeSize: index out of bounds") # t
+             Just i' =>
+               (plus acc (at sizes i')) # t
+    go acc sh (Balanced  (b ** arr))        t =
+      let i := minus b 1
+        in case tryNatToFin i of
+             Nothing =>
+               (assert_total $ idris_crash "Data.RRBVector1.Internal.treeSize: index out of bounds") # t
+             Just i' =>
+               let i'' # t := get arr i' t
+                 in go (plus acc (mult i (integerToNat (1 `shiftL` sh))))
+                       (down sh)
+                       (assert_smaller arr i'')
+                       t
+
+||| Turns an array into a tree node by computing the sizes of its subtrees.
+||| sh is the shift of the resulting tree.
+export
+computeSizes :  {n : Nat}
+             -> Shift
+             -> MArray s n (Tree1 s a)
+             -> F1 s (Tree1 s a)
+computeSizes sh arr t =
+  let isbalanced # t := isBalanced arr t
+    in case isbalanced of
+         True  =>
+           (Balanced {bsize=n} (n ** arr)) # t
+         False =>
+           let arrnat # t := createArrNat arr t
+             in (Unbalanced {usize=n} (n ** arr) arrnat) # t
+  where
+    createArrNat :  MArray s n (Tree1 s a)
+                 -> F1 s (IArray n Nat)
+    createArrNat arr t =
+      let tant # t := unsafeMArray1 n t
+        in go 0 n 0 tant t
+      where
+        go :  (m, x, acc : Nat)
+           -> (an : MArray s n Nat)
+           -> {auto v : Ix x n}
+           -> F1 s (IArray n Nat)
+        go m Z     acc an t =
+          freeze an t
+        go m (S j) acc an t =
+          let j'       # t := getIx arr j t
+              treesize # t := treeSize (down sh) j' t
+              acc'         := plus acc treesize
+            in case tryNatToFin m of
+                 Nothing =>
+                   (assert_total $ idris_crash "Data.RRBVector.Internal.computeSizes.createArrNat.go: can't convert Nat to Fin") # t
+                 Just m' =>
+                   let () # t := set an m' acc' t
+                     in go (S m) j acc' an t
+    maxsize : Integer
+    maxsize = 1 `shiftL` sh -- the maximum size of a subtree
+    lenM1 : Nat
+    lenM1 = minus n 1
+    isBalanced :  {n : Nat}
+               -> MArray s n (Tree1 s a)
+               -> F1 s Bool
+    isBalanced arr t =
+      let bool' # t := go arr 0 t
+        in bool' # t
+      where
+        go :  {n : Nat}
+           -> MArray s n (Tree1 s a)
+           -> Nat
+           -> F1 s Bool
+        go arr i t =
+          case tryNatToFin i of
+            Nothing =>
+              (assert_total $ idris_crash "Data.RRBVector.Internal.computeSizes.isBalanced: can't convert Nat to Fin") # t
+            Just i' =>
+              let subtree # t := get arr i' t
+                in case i < lenM1 of
+                     True  =>
+                       let go'      # t := assert_total $ go arr (plus i 1) t
+                           treesize # t := treeSize (down sh) subtree t
+                         in ((natToInteger treesize == maxsize) && go') # t
+                     False =>
+                       treeBalanced subtree # t
+
+export
+countTrailingZeros :  Nat
+                   -> Nat
+countTrailingZeros x =
+  go 0
+  where
+    w : Nat
+    w = bitSizeOf Int
+    go : Nat -> Nat
+    go i =
+      case i >= w of
+        True  =>
+          i
+        False =>
+          case tryNatToFin i of
+            Nothing =>
+              assert_total $ idris_crash "Data.RRBVector1.Internal.countTrailingZeros: can't convert Nat to Fin"
+            Just i' =>
+              case testBit (the Int (cast x)) i' of
+                True  =>
+                  i
+                False =>
+                  assert_total $ go (plus i 1)
+
+||| Nat log base 2.
+export
+log2 :  Nat
+     -> Nat
+log2 x =
+  let bitSizeMinus1 = minus (bitSizeOf Int) 1
+    in minus bitSizeMinus1 (countLeadingZeros x)
+  where
+    countLeadingZeros : Nat -> Nat
+    countLeadingZeros x =
+      minus (minus w 1) (go (minus w 1))
+      where
+        w : Nat
+        w = bitSizeOf Int
+        go : Nat -> Nat
+        go i =
+          case i < 0 of
+            True  =>
+              i
+            False =>
+              case tryNatToFin i of
+                Nothing =>
+                  assert_total $ idris_crash "Data.RRBVector1.Internal.log2: can't convert Nat to Fin"
+                Just i' =>
+                  case testBit (the Int (cast x)) i' of
+                    True  =>
+                      i
+                    False =>
+                      assert_total $ go (minus i 1)
+
+--------------------------------------------------------------------------------
+--          Linear RRB Vectors
+--------------------------------------------------------------------------------
+
+||| A linear relaxed radix balanced vector (RRBVector1).
+||| It supports fast indexing, iteration, concatenation and splitting.
+public export
+data RRBVector1 : (s : Type) -> Type -> Type where
+  Root  :  Nat   -- size
+        -> Shift -- shift (blockshift * height)
+        -> Tree1 s a
+        -> RRBVector1 s a
+  Empty : RRBVector1 s a

--- a/test/src/Main.idr
+++ b/test/src/Main.idr
@@ -9,7 +9,8 @@ import NatPSQ
 import OrdPSQ
 import RRBVector.Sized
 import RRBVector.Unsized
-import RRBVector1
+import RRBVector1.Sized
+import RRBVector1.Unsized
 import Seq.Sized
 import Seq.Unsized
 import Set
@@ -26,7 +27,8 @@ main = test
   , OrdPSQ.props
   , RRBVector.Sized.props
   , RRBVector.Unsized.props
-  , RRBVector1.props
+  , RRBVector1.Sized.props
+  , RRBVector1.Unsized.props
   , Seq.Sized.props
   , Seq.Unsized.props
   , Set.props

--- a/test/src/RRBVector1/Sized.idr
+++ b/test/src/RRBVector1/Sized.idr
@@ -1,0 +1,153 @@
+module RRBVector1.Sized
+
+import Hedgehog
+import Data.Linear.Ref1
+import Data.Linear.Token
+import Data.List
+import Data.RRBVector1.Sized
+
+%hide Prelude.toList
+%hide Prelude.Ops.infixl.(|>)
+%hide Prelude.Ops.infixr.(<|)
+%hide Prelude.Stream.(::)
+
+listOf : Gen a -> Gen (List a)
+listOf g = list (linear 0 20) g
+
+listOf' : Gen a -> Gen (List a)
+listOf' g = list (linear 1 20) g
+
+listBits : Gen (List Bits8)
+listBits = listOf anyBits8
+
+listBits' : Gen (List Bits8)
+listBits' = listOf' anyBits8
+
+prop_eq_refl : Property
+prop_eq_refl = property $ do
+  vs <- forAll listBits
+  ( run1 $ \t =>
+      let vs' # t := fromList vs t
+        in toList vs' t ) ===
+  ( run1 $ \t =>
+      let vs' # t := fromList vs t
+        in toList vs' t )
+
+prop_map_id : Property
+prop_map_id = property $ do
+  vs <- forAll listBits
+  ( run1 $ \t =>
+      let vs'         # t := fromList vs t
+          (_ ** vs'') # t := Data.RRBVector1.Sized.map id vs' t
+        in toList vs'' t ) === map id vs
+
+prop_from_to_list : Property
+prop_from_to_list = property $ do
+  vs <- forAll listBits
+  ( run1 $ \t =>
+      let vs' # t := fromList vs t
+        in toList vs' t ) === vs
+
+prop_null : Property
+prop_null = property $ do
+  vs <- forAll listBits
+  ( run1 $ \t =>
+      let vs' # t := fromList vs t
+        in Data.RRBVector1.Sized.null vs' t ) === null vs
+
+prop_size : Property
+prop_size = property $ do
+  vs <- forAll listBits
+  ( run1 $ \t =>
+      let vs' # t := fromList vs t
+        in Data.RRBVector1.Sized.length vs' t ) === length vs
+
+prop_replicate : Property
+prop_replicate = property $ do
+  ( run1 $ \t =>
+      let vs' # t := Data.RRBVector1.Sized.replicate 5 1 t
+        in toList vs' t ) === replicate 5 1
+
+prop_take : Property
+prop_take = property $ do
+  vs <- forAll listBits
+  ( run1 $ \t =>
+      let vs'         # t := fromList vs t
+          (_ ** vs'') # t := Data.RRBVector1.Sized.take 1 vs' t
+        in toList vs'' t ) === take 1 vs
+
+prop_drop : Property
+prop_drop = property $ do
+  vs <- forAll listBits
+  ( run1 $ \t =>
+      let vs'         # t := fromList vs t
+          (_ ** vs'') # t := Data.RRBVector1.Sized.drop ((length vs) `minus` 1) vs' t
+        in toList vs'' t ) === drop ((length vs) `minus` 1) vs
+
+prop_cons : Property
+prop_cons = property $ do
+  vs <- forAll listBits
+  ( run1 $ \t =>
+      let vs'         # t := fromList vs t
+          (_ ** vs'') # t := (Data.RRBVector1.Sized.(<|)) 1 vs' t
+        in toList vs'' t ) === 1 :: vs
+
+prop_snoc : Property
+prop_snoc = property $ do
+  vs <- forAll listBits
+  ( run1 $ \t =>
+      let vs'         # t := fromList vs t
+          (_ ** vs'') # t := Data.RRBVector1.Sized.(|>) vs' 1 t
+        in toList vs'' t ) === vs ++ [1]
+
+prop_concat : Property
+prop_concat = property $ do
+  x <- forAll listBits
+  y <- forAll listBits
+  ( run1 $ \t =>
+      let x'         # t := fromList x t
+          y'         # t := fromList y t
+          (_ ** xy') # t := (><) x' y' t
+        in toList xy' t ) === x ++ y
+
+prop_insertAt : Property
+prop_insertAt = property $ do
+  vs <- forAll listBits
+  case isLTE 0 (length vs) of
+    No  _   =>
+      assert_total $ idris_crash "index not within bounds of list"
+    Yes prf =>
+      ( run1 $ \t =>
+          let vs'         # t := fromList vs t
+              (_ ** vs'') # t := Data.RRBVector1.Sized.insertAt 0 0 vs' t
+            in toList vs'' t ) === insertAt 0 0 @{prf} vs
+
+prop_deleteAt : Property
+prop_deleteAt = property $ do
+  vs <- forAll listBits'
+  case inBounds 0 vs of
+    No  _   =>
+      assert_total $ idris_crash "index not within bounds of list"
+    Yes prf =>
+      ( run1 $ \t =>
+          let vs'         # t := fromList vs t
+              (_ ** vs'') # t := Data.RRBVector1.Sized.deleteAt 0 vs' t
+            in toList vs'' t ) === deleteAt 0 vs @{prf}
+
+export
+props : Group
+props = MkGroup "RRBVector1 (Sized)"
+  [ ("prop_eq_refl", prop_eq_refl)
+  , ("prop_map_id", prop_map_id)
+  , ("prop_from_to_list", prop_from_to_list)
+  , ("prop_null", prop_null)
+  , ("prop_size", prop_size)
+  , ("prop_replicate", prop_replicate)
+  , ("prop_take", prop_take)
+  , ("prop_drop", prop_drop)
+  , ("prop_cons", prop_cons)
+  , ("prop_snoc", prop_snoc)
+  , ("prop_concat", prop_concat)
+  , ("prop_insertAt", prop_insertAt)
+  , ("prop_deleteAt", prop_deleteAt)
+  ]

--- a/test/src/RRBVector1/Unsized.idr
+++ b/test/src/RRBVector1/Unsized.idr
@@ -1,10 +1,10 @@
-module RRBVector1
+module RRBVector1.Unsized
 
 import Hedgehog
 import Data.Linear.Ref1
 import Data.Linear.Token
 import Data.List
-import Data.RRBVector1
+import Data.RRBVector1.Unsized
 
 %hide Prelude.toList
 %hide Prelude.Ops.infixl.(|>)
@@ -38,7 +38,7 @@ prop_map_id = property $ do
   vs <- forAll listBits
   ( run1 $ \t =>
       let vs'  # t := fromList vs t
-          vs'' # t := Data.RRBVector1.map id vs' t
+          vs'' # t := Data.RRBVector1.Unsized.map id vs' t
         in toList vs'' t ) === map id vs
 
 prop_from_to_list : Property
@@ -53,19 +53,19 @@ prop_null = property $ do
   vs <- forAll listBits
   ( run1 $ \t =>
       let vs' # t := fromList vs t
-        in Data.RRBVector1.null vs' t ) === null vs
+        in Data.RRBVector1.Unsized.null vs' t ) === null vs
 
 prop_size : Property
 prop_size = property $ do
   vs <- forAll listBits
   ( run1 $ \t =>
       let vs' # t := fromList vs t
-        in Data.RRBVector1.length vs' t ) === length vs
+        in Data.RRBVector1.Unsized.length vs' t ) === length vs
 
 prop_replicate : Property
 prop_replicate = property $ do
   ( run1 $ \t =>
-      let vs' # t := Data.RRBVector1.replicate 5 1 t
+      let vs' # t := Data.RRBVector1.Unsized.replicate 5 1 t
         in toList vs' t ) === replicate 5 1
 
 prop_take : Property
@@ -73,7 +73,7 @@ prop_take = property $ do
   vs <- forAll listBits
   ( run1 $ \t =>
       let vs'  # t := fromList vs t
-          vs'' # t := Data.RRBVector1.take 1 vs' t
+          vs'' # t := Data.RRBVector1.Unsized.take 1 vs' t
         in toList vs'' t ) === take 1 vs
 
 prop_drop : Property
@@ -81,7 +81,7 @@ prop_drop = property $ do
   vs <- forAll listBits
   ( run1 $ \t =>
       let vs'  # t := fromList vs t
-          vs'' # t := Data.RRBVector1.drop ((length vs) `minus` 1) vs' t
+          vs'' # t := Data.RRBVector1.Unsized.drop ((length vs) `minus` 1) vs' t
         in toList vs'' t ) === drop ((length vs) `minus` 1) vs
 
 prop_cons : Property
@@ -89,7 +89,7 @@ prop_cons = property $ do
   vs <- forAll listBits
   ( run1 $ \t =>
       let vs'  # t := fromList vs t
-          vs'' # t := (Data.RRBVector1.(<|)) 1 vs' t
+          vs'' # t := (Data.RRBVector1.Unsized.(<|)) 1 vs' t
         in toList vs'' t ) === 1 :: vs
 
 prop_snoc : Property
@@ -97,7 +97,7 @@ prop_snoc = property $ do
   vs <- forAll listBits
   ( run1 $ \t =>
       let vs'  # t := fromList vs t
-          vs'' # t := Data.RRBVector1.(|>) vs' 1 t
+          vs'' # t := Data.RRBVector1.Unsized.(|>) vs' 1 t
         in toList vs'' t ) === vs ++ [1]
 
 prop_concat : Property
@@ -119,7 +119,7 @@ prop_insertAt = property $ do
     Yes prf =>
       ( run1 $ \t =>
           let vs'  # t := fromList vs t
-              vs'' # t := Data.RRBVector1.insertAt 0 0 vs' t
+              vs'' # t := Data.RRBVector1.Unsized.insertAt 0 0 vs' t
             in toList vs'' t ) === insertAt 0 0 @{prf} vs
 
 prop_deleteAt : Property
@@ -131,12 +131,12 @@ prop_deleteAt = property $ do
     Yes prf =>
       ( run1 $ \t =>
           let vs'  # t := fromList vs t
-              vs'' # t := Data.RRBVector1.deleteAt 0 vs' t
+              vs'' # t := Data.RRBVector1.Unsized.deleteAt 0 vs' t
             in toList vs'' t ) === deleteAt 0 vs @{prf}
 
 export
 props : Group
-props = MkGroup "RRBVector1"
+props = MkGroup "RRBVector1 (Unsized)"
   [ ("prop_eq_refl", prop_eq_refl)
   , ("prop_map_id", prop_map_id)
   , ("prop_from_to_list", prop_from_to_list)


### PR DESCRIPTION
This PR refactors `RRBVector1` into `Sized` and `Unsized`:

`Sized`:

```
data RRBVector1 : (s : Type) -> (n : Nat) -> Type -> Type where
  Root  :  Shift -- shift (blockshift * height)
        -> Tree1 s a
        -> RRBVector1 s n a
  Empty : RRBVector1 s n a
```

`Unsized`:

```
data RRBVector1 : (s : Type) -> Type -> Type where
  Root  :  Nat   -- size
        -> Shift -- shift (blockshift * height)
        -> Tree1 s a
        -> RRBVector1 s a
  Empty : RRBVector1 s a
```

The test suite is also updated to reflect the split into `Sized` and `Unsized`.
