### PR TITLE
[ workflow ] Add test to build workflow

### DIFF
--- a/.github/workflows/ci-lib.yml
+++ b/.github/workflows/ci-lib.yml
@@ -29,3 +29,5 @@ jobs:
         uses: actions/checkout@v2
       - name: Build lib
         run: pack --no-prompt install containers
+      - name: Run test
+        run: pack test containers


### PR DESCRIPTION
This PR augments `ci-lib.yml` so that it runs the `test` suite during the `build` workflow.