### PR TITLE
[ refactor ] Split BoundedQueue into Sized and Unsized

### DIFF
--- a/containers.ipkg
+++ b/containers.ipkg
@@ -9,7 +9,8 @@ depends    = base         >= 0.6.0
            , elab-util
            , hashable
            , ref1
-modules    = Data.BoundedQueue
+modules    = Data.BoundedQueue.Sized
+           , Data.BoundedQueue.Unsized
            , Data.FVect
            , Data.FVect.Capacity
            , Data.HashPSQ

--- a/src/Data/BoundedQueue/Sized.idr
+++ b/src/Data/BoundedQueue/Sized.idr
@@ -1,0 +1,176 @@
+||| Bounded Queues
+module Data.BoundedQueue.Sized
+
+import Data.Seq.Sized
+import Derive.Prelude
+
+%hide Data.Vect.length
+%hide Prelude.take
+
+%language ElabReflection
+
+%default total
+
+||| An immutable, bounded first-in first-out structure which keeps
+||| track of its size, with amortized O(1) enqueue and dequeue operations.
+export
+data BoundedQueue : (m : Nat) -> (n : Nat) -> (a : Type) -> Type where
+  MkBoundedQueue :  Seq n a -- queue
+                 -> BoundedQueue m n a
+
+||| The empty `BoundedQueue`. O(1)
+export
+empty :  (l : Nat)
+      -> BoundedQueue l 0 a
+empty _ =
+  MkBoundedQueue empty
+
+||| Is the `BoundedQueue` empty? O(1)
+export
+null :  {n : Nat}
+     -> BoundedQueue m n a
+     -> Bool
+null (MkBoundedQueue _) =
+  case n of
+    0 =>
+      True
+    _ =>
+      False
+
+||| Naively keeps the first `o` values of a list, and converts
+||| into a `BoundedQueue` (keeps the order of the elements). O(1)
+export
+fromList :  (o : Nat)
+         -> (vs : List a)
+         -> BoundedQueue o (length $ take o vs) a
+fromList o vs =
+  MkBoundedQueue (fromList $ take o vs)
+
+||| Naively keeps the first `o` values of a `SnocList`, and converts
+||| into a `BoundedQueue` (keeps the order of the elements). O(1)
+export
+fromSnocList :  (o : Nat)
+             -> (sv : SnocList a)
+             -> BoundedQueue o (Prelude.List.length $ take o $ cast {to=List a} sv) a
+fromSnocList o sv =
+  MkBoundedQueue (fromList $ take o $ cast sv)
+
+||| Converts a `BoundedQueue` to a `List`, keeping the order
+||| of elements. O(n)
+export
+toList :  BoundedQueue m n a
+       -> List a
+toList (MkBoundedQueue queue) =
+  toList queue
+
+||| Converts a `BoundedQueue` to a `SnocList`, keeping the order
+||| of elements. O(n)
+export
+toSnocList :  BoundedQueue m n a
+           -> SnocList a
+toSnocList (MkBoundedQueue queue) =
+  cast $ toList queue
+
+||| Append a value at the back of the `BoundedQueue`. O(1)
+export
+enqueue :  {m : Nat}
+        -> {n : Nat}
+        -> BoundedQueue m n a
+        -> a
+        -> (n' ** BoundedQueue m n' a)
+enqueue (MkBoundedQueue queue) v {n = 0}   =
+  (1 ** MkBoundedQueue (queue `snoc` v))
+enqueue (MkBoundedQueue queue) v {n = S n} =
+  case m == n of
+    True  =>
+      let (_, queue') = viewl queue
+        in ((S n) ** MkBoundedQueue (queue' `snoc` v))
+    False =>
+      ((S (S n)) ** MkBoundedQueue (queue `snoc` v))
+
+||| Take a value from the front of the `BoundedQueue`. O(1)
+export
+dequeue :  {n : Nat}
+        -> BoundedQueue m n a
+        -> Maybe (a, (n' ** BoundedQueue m n' a))
+dequeue (MkBoundedQueue queue) {n = 0}   =
+  Nothing
+dequeue (MkBoundedQueue queue) {n = S n} =
+  let (h, queue') = viewl queue
+    in Just (h, (n ** MkBoundedQueue queue')
+            )
+
+||| We can prepend an element to our `BoundedQueue`, making it the new
+||| "oldest" element. O(1)
+|||
+||| This is against the typical use case for a FIFO data
+||| structure, but it allows us to conveniently implement
+||| `peekOldest`.
+export
+prepend :  {m : Nat}
+        -> {n : Nat}
+        -> (x : a)
+        -> BoundedQueue m n a
+        -> (n' ** BoundedQueue m n' a)
+prepend x (MkBoundedQueue queue) {n = 0}   =
+  (1 ** MkBoundedQueue (x `cons` queue))
+prepend x (MkBoundedQueue queue) {n = S n} =
+  case m == n of
+    True  =>
+      let (_, queue') = viewl queue
+        in ((S n) ** MkBoundedQueue (x `cons` queue'))
+    False =>
+      ((S (S n)) ** MkBoundedQueue (x `cons` queue))
+
+||| Return the last element of the `BoundedQueue`, plus the unmodified
+||| queue.
+|||
+||| Note: `peekOldest` might involve a rearrangement of the elements
+|||       just like `dequeue`. In order to keep our amortized O(1)
+|||       runtime behavior, the newly arranged queue should be used
+|||       henceforth.
+export
+peekOldest :  {n : Nat}
+           -> BoundedQueue m n a
+           -> Maybe (a, (n' ** BoundedQueue m n' a))
+peekOldest q =
+  case dequeue q of
+    Just (v, (n' ** MkBoundedQueue queue)
+         ) =>
+      Just (v, ((S n') ** MkBoundedQueue (v `cons` queue))
+           )
+    Nothing                                =>
+      Nothing
+
+||| Appends two `BoundedQueues`. O(m + n)
+export
+(++) :  BoundedQueue m1 n1 a
+     -> BoundedQueue m2 n2 a
+     -> BoundedQueue (m1 `plus` m2) (n1 `plus` n2) a
+(MkBoundedQueue queue1) ++ (MkBoundedQueue queue2) =
+  MkBoundedQueue (queue1 ++ queue2)
+
+||| Returns the length of the `BoundedQueue`. O(1).
+export
+length :  {n : Nat}
+       -> BoundedQueue m n a
+       -> Nat
+length (MkBoundedQueue _) =
+  n
+
+--------------------------------------------------------------------------------
+--          Interfaces
+--------------------------------------------------------------------------------
+
+export
+{n : Nat} -> Eq a => Eq (BoundedQueue m n a) where
+  xs == ys = length xs == length ys && Data.BoundedQueue.Sized.toList xs == Data.BoundedQueue.Sized.toList ys
+
+export
+{n : Nat} -> Ord a => Ord (BoundedQueue m n a) where
+  compare xs ys = compare (Data.BoundedQueue.Sized.toList xs) (Data.BoundedQueue.Sized.toList ys)
+
+export
+Functor (BoundedQueue m n) where
+  map f (MkBoundedQueue queue) =
+    MkBoundedQueue (map f queue)

--- a/src/Data/BoundedQueue/Sized.idr
+++ b/src/Data/BoundedQueue/Sized.idr
@@ -174,3 +174,7 @@ export
 Functor (BoundedQueue m n) where
   map f (MkBoundedQueue queue) =
     MkBoundedQueue (map f queue)
+
+export
+Show a => Show (BoundedQueue m n a) where
+  show (MkBoundedQueue queue) = show queue

--- a/src/Data/BoundedQueue/Unsized.idr
+++ b/src/Data/BoundedQueue/Unsized.idr
@@ -1,5 +1,5 @@
 ||| Bounded Queues
-module Data.BoundedQueue
+module Data.BoundedQueue.Unsized
 
 import Data.Seq.Unsized
 import Derive.Prelude
@@ -11,26 +11,28 @@ import Derive.Prelude
 ||| An immutable, bounded first-in first-out structure which keeps
 ||| track of its size, with amortized O(1) enqueue and dequeue operations.
 export
-record BoundedQueue a where
-  constructor Q
-  queue      : Seq a
-  queuelimit : Nat
-  queuesize  : Nat
+data BoundedQueue : (a : Type) -> Type where
+  MkBoundedQueue :  Seq a -- queue
+                 -> Nat   -- limit
+                 -> Nat   -- size
+                 -> BoundedQueue a
 
 ||| The empty `BoundedQueue`. O(1)
 export
 empty :  Nat
       -> BoundedQueue a
 empty l =
-  Q empty l 0
+  MkBoundedQueue empty
+                 l
+                 0
 
 ||| Is the `BoundedQueue` empty? O(1)
 export
 null :  BoundedQueue a
      -> Bool
-null (Q _ _ 0) =
+null (MkBoundedQueue _ _ 0) =
   True
-null _         =
+null _                      =
   False
 
 ||| Naively keeps the first `n` values of a list, and converts
@@ -41,7 +43,9 @@ fromList :  Nat
          -> BoundedQueue a
 fromList n vs =
   let vs' = take n vs
-    in Q (fromList vs') n (length vs')
+    in MkBoundedQueue (fromList vs')
+                      n
+                      (length vs')
 
 ||| Naively keeps the first `n` values of a `SnocList`, and converts
 ||| into a `BoundedQueue` (keeps the order of the elements). O(1)
@@ -51,14 +55,16 @@ fromSnocList :  Nat
              -> BoundedQueue a
 fromSnocList n sv =
   let sv' = take n $ cast sv
-    in Q (fromList sv') n (length sv')
+    in MkBoundedQueue (fromList sv')
+                      n
+                      (length sv')
 
 ||| Converts a `BoundedQueue` to a `List`, keeping the order
 ||| of elements. O(n)
 export
 toList :  BoundedQueue a
        -> List a
-toList (Q queue _ _) =
+toList (MkBoundedQueue queue _ _) =
   toList queue
 
 ||| Converts a `BoundedQueue` to a `SnocList`, keeping the order
@@ -66,7 +72,7 @@ toList (Q queue _ _) =
 export
 toSnocList :  BoundedQueue a
            -> SnocList a
-toSnocList (Q queue _ _) =
+toSnocList (MkBoundedQueue queue _ _) =
   cast $ toList queue
 
 ||| Append a value at the back of the `BoundedQueue`. O(1)
@@ -74,27 +80,36 @@ export
 enqueue :  BoundedQueue a
         -> a
         -> BoundedQueue a
-enqueue (Q queue queuelimit queuesize) v =
+enqueue (MkBoundedQueue queue queuelimit queuesize) v =
   case queuelimit == queuesize of
     True  =>
       case viewl queue of
         Nothing          =>
-          Q queue queuelimit queuesize
+          MkBoundedQueue queue
+                         queuelimit
+                         queuesize
         Just (_, queue') =>
-          Q (queue' `snoc` v) queuelimit queuesize
+          MkBoundedQueue (queue' `snoc` v)
+                         queuelimit
+                         queuesize
     False =>
-      Q (queue `snoc` v) queuelimit (queuesize `plus` 1)
+      MkBoundedQueue (queue `snoc` v)
+                     queuelimit
+                     (queuesize `plus` 1)
 
 ||| Take a value from the front of the `BoundedQueue`. O(1)
 export
 dequeue :  BoundedQueue a
         -> Maybe (a, BoundedQueue a)
-dequeue (Q queue queuelimit queuesize) =
+dequeue (MkBoundedQueue queue queuelimit queuesize) =
   case viewl queue of
     Nothing          =>
       Nothing
     Just (h, queue') =>
-      Just (h, Q queue' queuelimit (queuesize `minus` 1))
+      Just (h, MkBoundedQueue queue'
+                              queuelimit
+                              (queuesize `minus` 1)
+           )
 
 ||| We can prepend an element to our `BoundedQueue`, making it the new
 ||| "oldest" element. O(1)
@@ -106,16 +121,22 @@ export
 prepend :  a
         -> BoundedQueue a
         -> BoundedQueue a
-prepend x (Q queue queuelimit queuesize) =
+prepend x (MkBoundedQueue queue queuelimit queuesize) =
   case queuelimit == queuesize of
     True  =>
       case viewl queue of
         Nothing          =>
-          Q queue queuelimit queuesize
+          MkBoundedQueue queue
+                         queuelimit
+                         queuesize
         Just (_, queue') =>
-          Q (x `cons` queue') queuelimit queuesize
+          MkBoundedQueue (x `cons` queue')
+                         queuelimit
+                         queuesize
     False =>
-      Q (x `cons` queue) queuelimit (queuesize `plus` 1)
+      MkBoundedQueue (x `cons` queue)
+                     queuelimit
+                     (queuesize `plus` 1)
 
 ||| Return the last element of the `BoundedQueue`, plus the unmodified
 ||| queue.
@@ -129,8 +150,14 @@ peekOldest :  BoundedQueue a
            -> Maybe (a, BoundedQueue a)
 peekOldest q =
   case dequeue q of
-    Just (v, Q queue queuelimit queuesize) =>
-      Just (v, Q (v `cons` queue) queuelimit (queuesize `plus` 1))
+    Just (v, MkBoundedQueue queue
+                            queuelimit
+                            queuesize
+         ) =>
+      Just (v, MkBoundedQueue (v `cons` queue)
+                              queuelimit
+                              (queuesize `plus` 1)
+           )
     Nothing                                =>
       Nothing
 
@@ -139,14 +166,17 @@ export
 (++) :  BoundedQueue a
      -> BoundedQueue a
      -> BoundedQueue a
-(Q queue1 queuelimit1 queuesize1) ++ (Q queue2 queuelimit2 queuesize2) =
-  Q (queue1 ++ queue2) (queuelimit1 `plus` queuelimit2) (queuesize1 `plus` queuesize2)
+(MkBoundedQueue queue1 queuelimit1 queuesize1) ++ (MkBoundedQueue queue2 queuelimit2 queuesize2) =
+  MkBoundedQueue (queue1 ++ queue2)
+                 (queuelimit1 `plus` queuelimit2)
+                 (queuesize1 `plus` queuesize2)
 
 ||| Returns the length of the `BoundedQueue`. O(1).
 export
 length :  BoundedQueue a
        -> Nat
-length (Q _ _ queuesize) = queuesize
+length (MkBoundedQueue _ _ queuesize) =
+  queuesize
 
 --------------------------------------------------------------------------------
 --          Interfaces
@@ -164,4 +194,7 @@ Monoid (BoundedQueue a) where
 
 export
 Functor BoundedQueue where
-  map f (Q queue queuelimit queuesize) = Q (map f queue) queuelimit queuesize
+  map f (MkBoundedQueue queue queuelimit queuesize) =
+    MkBoundedQueue (map f queue)
+                   queuelimit
+                   queuesize

--- a/src/Data/BoundedQueue/Unsized.idr
+++ b/src/Data/BoundedQueue/Unsized.idr
@@ -17,6 +17,8 @@ data BoundedQueue : (a : Type) -> Type where
                  -> Nat   -- size
                  -> BoundedQueue a
 
+%runElab derive "BoundedQueue" [Show,Eq,Ord]
+
 ||| The empty `BoundedQueue`. O(1)
 export
 empty :  Nat
@@ -181,8 +183,6 @@ length (MkBoundedQueue _ _ queuesize) =
 --------------------------------------------------------------------------------
 --          Interfaces
 --------------------------------------------------------------------------------
-
-%runElab derive "BoundedQueue" [Show,Eq]
 
 export
 Semigroup (BoundedQueue a) where

--- a/src/Data/Seq/Sized.idr
+++ b/src/Data/Seq/Sized.idr
@@ -153,7 +153,7 @@ fromList xs =
 
 ||| Turn a sequence into a vector. O(n)
 export
-toVect :  {n :Nat}
+toVect :  {n : Nat}
        -> Seq n a
        -> Vect n a
 toVect _  {n = 0}   =

--- a/test/src/BoundedQueue/Sized.idr
+++ b/test/src/BoundedQueue/Sized.idr
@@ -1,0 +1,69 @@
+module BoundedQueue.Sized
+
+import Hedgehog
+import Data.List
+import Data.BoundedQueue.Sized
+
+%hide Prelude.Interfaces.toList
+%hide Prelude.Stream.(::)
+
+boundedqueueOf : (xs : List a) -> Gen (BoundedQueue (length xs) (length $ take (length xs) xs) a)
+boundedqueueOf xs = pure $ fromList (Prelude.Types.List.length xs) xs
+
+boundedqueueBits : (xs : List Bits8) -> Gen (BoundedQueue (length xs) (length $ take (length xs) xs) Bits8)
+boundedqueueBits xs = pure $ fromList (Prelude.Types.List.length xs) xs
+
+prop_eq_refl : Property
+prop_eq_refl = property $ do
+  xs <- forAll (list (linear 0 20) anyBits8)
+  vs <- forAll $ boundedqueueBits xs
+  vs === vs
+
+prop_map_id : Property
+prop_map_id = property $ do
+  xs <- forAll (list (linear 0 20) anyBits8)
+  vs <- forAll $ boundedqueueBits xs
+  vs === map id vs
+
+prop_from_to_list : Property
+prop_from_to_list = property $ do
+  vs <- forAll (list (linear 0 10) anyBits8)
+  toList (fromList (length vs) vs) === vs
+
+prop_null : Property
+prop_null = property $ do
+  xs <- forAll (list (linear 0 20) anyBits8)
+  vs <- forAll $ boundedqueueBits xs
+  Data.BoundedQueue.Sized.null vs === null (toList vs)
+
+prop_size : Property
+prop_size = property $ do
+  xs <- forAll (list (linear 0 20) anyBits8)
+  vs <- forAll $ boundedqueueBits xs
+  length vs === length (toList vs)
+
+prop_enqueue : Property
+prop_enqueue = property $ do
+  xs <- forAll (list (linear 0 20) anyBits8)
+  vs <- forAll $ boundedqueueBits xs
+  let (_ ** vs') = enqueue vs 1
+  (toList vs) ++ [1] === toList vs'
+
+prop_prepend : Property
+prop_prepend = property $ do
+  xs <- forAll (list (linear 0 20) anyBits8)
+  vs <- forAll $ boundedqueueBits xs
+  let (_ ** vs') = prepend 1 vs
+  (1 :: (toList vs)) === (toList vs')
+
+export
+props : Group
+props = MkGroup "BoundedQueue (Sized)"
+  [ ("prop_eq_refl", prop_eq_refl)
+  , ("prop_map_id", prop_map_id)
+  , ("prop_from_to_list", prop_from_to_list)
+  , ("prop_null", prop_null)
+  , ("prop_size", prop_size)
+  , ("prop_enqueue", prop_enqueue)
+  , ("prop_prepend", prop_prepend)
+  ]

--- a/test/src/BoundedQueue/Unsized.idr
+++ b/test/src/BoundedQueue/Unsized.idr
@@ -1,8 +1,8 @@
-module BoundedQueue
+module BoundedQueue.Unsized
 
 import Hedgehog
 import Data.List
-import Data.BoundedQueue
+import Data.BoundedQueue.Unsized
 
 %hide Prelude.Interfaces.toList
 %hide Prelude.Ops.infixl.(|>)
@@ -43,7 +43,7 @@ prop_from_to_list = property $ do
 prop_null : Property
 prop_null = property $ do
   vs <- forAll boundedqueueBits
-  null vs === null (Data.BoundedQueue.toList vs)
+  null vs === null (Data.BoundedQueue.Unsized.toList vs)
 
 prop_size : Property
 prop_size = property $ do
@@ -62,7 +62,7 @@ prop_prepend = property $ do
 
 export
 props : Group
-props = MkGroup "BoundedQueue"
+props = MkGroup "BoundedQueue (Unsized)"
   [ ("prop_eq_refl", prop_eq_refl)
   , ("prop_map_id", prop_map_id)
   , ("prop_from_to_list", prop_from_to_list)

--- a/test/src/BoundedQueue/Unsized.idr
+++ b/test/src/BoundedQueue/Unsized.idr
@@ -5,8 +5,6 @@ import Data.List
 import Data.BoundedQueue.Unsized
 
 %hide Prelude.Interfaces.toList
-%hide Prelude.Ops.infixl.(|>)
-%hide Prelude.Ops.infixr.(<|)
 %hide Prelude.Stream.(::)
 
 boundedqueueOf : Gen a -> Gen (BoundedQueue a)

--- a/test/src/Main.idr
+++ b/test/src/Main.idr
@@ -1,5 +1,6 @@
 module Main
 
+import BoundedQueue.Sized
 import BoundedQueue.Unsized
 import HashPSQ
 import Hedgehog
@@ -19,7 +20,8 @@ import Set
 
 main : IO ()
 main = test
-  [ BoundedQueue.Unsized.props
+  [ BoundedQueue.Sized.props
+  , BoundedQueue.Unsized.props
   , HashPSQ.props
   , LRUCache.props
   , Map.props

--- a/test/src/Main.idr
+++ b/test/src/Main.idr
@@ -1,6 +1,6 @@
 module Main
 
-import BoundedQueue
+import BoundedQueue.Unsized
 import HashPSQ
 import Hedgehog
 import LRUCache
@@ -19,7 +19,7 @@ import Set
 
 main : IO ()
 main = test
-  [ BoundedQueue.props
+  [ BoundedQueue.Unsized.props
   , HashPSQ.props
   , LRUCache.props
   , Map.props


### PR DESCRIPTION
This PR refactors `BoundedQueue` into Sized and Unsized:

`Sized`:

```
data BoundedQueue : (m : Nat) -> (n : Nat) -> (a : Type) -> Type where
  MkBoundedQueue :  Seq n a -- queue
                 -> BoundedQueue m n a
```

`Unsized`:

```
data BoundedQueue : (a : Type) -> Type where
  MkBoundedQueue :  Seq a -- queue
                 -> Nat   -- limit
                 -> Nat   -- size
                 -> BoundedQueue a
```