### PR TITLE
[ refactor ] Update documentation string for BoundedQueue (Sized)

### DIFF
--- a/src/Data/BoundedQueue/Sized.idr
+++ b/src/Data/BoundedQueue/Sized.idr
@@ -13,6 +13,8 @@ import Derive.Prelude
 
 ||| An immutable, bounded first-in first-out structure which keeps
 ||| track of its size, with amortized O(1) enqueue and dequeue operations.
+||| The `m` argument tracks the `BoundedQueue`s limit,
+||| and the `n` argument tracks the `BoundedQueue`s size.
 export
 data BoundedQueue : (m : Nat) -> (n : Nat) -> (a : Type) -> Type where
   MkBoundedQueue :  Seq n a -- queue


### PR DESCRIPTION
This PR adds information to the documentation string of `BoundedQueue` (`Sized`) detailing the significance of it's arguments.