### PR TITLE
[ refactor ] BoundedQueue Internals

### DIFF
--- a/containers.ipkg
+++ b/containers.ipkg
@@ -11,6 +11,8 @@ depends    = base         >= 0.6.0
            , ref1
 modules    = Data.BoundedQueue.Sized
            , Data.BoundedQueue.Unsized
+           , Data.BoundedQueue.Sized.Internal
+           , Data.BoundedQueue.Unsized.Internal
            , Data.FVect
            , Data.FVect.Capacity
            , Data.HashPSQ

--- a/src/Data/BoundedQueue/Sized.idr
+++ b/src/Data/BoundedQueue/Sized.idr
@@ -1,6 +1,8 @@
 ||| Bounded Queues
 module Data.BoundedQueue.Sized
 
+import Data.BoundedQueue.Sized.Internal
+
 import Data.Seq.Sized
 import Derive.Prelude
 
@@ -10,15 +12,6 @@ import Derive.Prelude
 %language ElabReflection
 
 %default total
-
-||| An immutable, bounded first-in first-out structure which keeps
-||| track of its size, with amortized O(1) enqueue and dequeue operations.
-||| The `m` argument tracks the `BoundedQueue`s limit,
-||| and the `n` argument tracks the `BoundedQueue`s size.
-export
-data BoundedQueue : (m : Nat) -> (n : Nat) -> (a : Type) -> Type where
-  MkBoundedQueue :  Seq n a -- queue
-                 -> BoundedQueue m n a
 
 ||| The empty `BoundedQueue`. O(1)
 export

--- a/src/Data/BoundedQueue/Sized/Internal.idr
+++ b/src/Data/BoundedQueue/Sized/Internal.idr
@@ -1,0 +1,15 @@
+||| Bounded Queue Internals
+module Data.BoundedQueue.Sized.Internal
+
+import Data.Seq.Sized
+
+%default total
+
+||| An immutable, bounded first-in first-out structure which keeps
+||| track of its size, with amortized O(1) enqueue and dequeue operations.
+||| The `m` argument tracks the `BoundedQueue`s limit,
+||| and the `n` argument tracks the `BoundedQueue`s size.
+public export
+data BoundedQueue : (m : Nat) -> (n : Nat) -> (a : Type) -> Type where
+  MkBoundedQueue :  Seq n a -- queue
+                 -> BoundedQueue m n a

--- a/src/Data/BoundedQueue/Unsized.idr
+++ b/src/Data/BoundedQueue/Unsized.idr
@@ -1,23 +1,14 @@
 ||| Bounded Queues
 module Data.BoundedQueue.Unsized
 
+import Data.BoundedQueue.Unsized.Internal
+
 import Data.Seq.Unsized
 import Derive.Prelude
 
 %language ElabReflection
 
 %default total
-
-||| An immutable, bounded first-in first-out structure which keeps
-||| track of its size, with amortized O(1) enqueue and dequeue operations.
-export
-data BoundedQueue : (a : Type) -> Type where
-  MkBoundedQueue :  Seq a -- queue
-                 -> Nat   -- limit
-                 -> Nat   -- size
-                 -> BoundedQueue a
-
-%runElab derive "BoundedQueue" [Show,Eq,Ord]
 
 ||| The empty `BoundedQueue`. O(1)
 export

--- a/src/Data/BoundedQueue/Unsized/Internal.idr
+++ b/src/Data/BoundedQueue/Unsized/Internal.idr
@@ -1,0 +1,20 @@
+||| Bounded Queue Internals
+module Data.BoundedQueue.Unsized.Internal
+
+import Data.Seq.Unsized
+import Derive.Prelude
+
+%language ElabReflection
+
+%default total
+
+||| An immutable, bounded first-in first-out structure which keeps
+||| track of its size, with amortized O(1) enqueue and dequeue operations.
+public export
+data BoundedQueue : (a : Type) -> Type where
+  MkBoundedQueue :  Seq a -- queue
+                 -> Nat   -- limit
+                 -> Nat   -- size
+                 -> BoundedQueue a
+
+%runElab derive "BoundedQueue" [Show,Eq,Ord]

--- a/test/src/BoundedQueue/Sized.idr
+++ b/test/src/BoundedQueue/Sized.idr
@@ -3,6 +3,7 @@ module BoundedQueue.Sized
 import Hedgehog
 import Data.List
 import Data.BoundedQueue.Sized
+import Data.BoundedQueue.Sized.Internal
 
 %hide Prelude.Interfaces.toList
 %hide Prelude.Stream.(::)

--- a/test/src/BoundedQueue/Unsized.idr
+++ b/test/src/BoundedQueue/Unsized.idr
@@ -3,6 +3,7 @@ module BoundedQueue.Unsized
 import Hedgehog
 import Data.List
 import Data.BoundedQueue.Unsized
+import Data.BoundedQueue.Unsized.Internal
 
 %hide Prelude.Interfaces.toList
 %hide Prelude.Stream.(::)


### PR DESCRIPTION
This PR refactors both `Sized` and `Unsized` `BoundedQueue`s such that each respective `BoundedQueue` data type is now contained within its own `Internal` module.