### PR TITLE
[ fix ] Various RRBVector and RRBVector1 fixes

### DIFF
--- a/src/Data/RRBVector/Sized.idr
+++ b/src/Data/RRBVector/Sized.idr
@@ -1264,7 +1264,14 @@ showRRBVectorRep (Root sh t) =
 
 export
 {n : Nat} -> Eq a => Eq (RRBVector n a) where
-  xs == ys = length xs == length ys && Data.RRBVector.Sized.toList xs == Data.RRBVector.Sized.toList ys
+  (Root sh1 tree1) == (Root sh2 tree2) =
+    sh1 == sh2 && Data.RRBVector.Sized.Internal.toList tree1 == Data.RRBVector.Sized.Internal.toList tree2
+  Empty            == Empty            =
+    True
+  (Root _   _    ) == Empty            =
+    False
+  Empty            == (Root _   _    ) =
+    False
 
 export
 {n : Nat} -> Ord a => Ord (RRBVector n a) where

--- a/src/Data/RRBVector/Sized/Internal.idr
+++ b/src/Data/RRBVector/Sized/Internal.idr
@@ -170,12 +170,15 @@ foldr f acc tree =
 --          Creating Lists from Trees
 --------------------------------------------------------------------------------
 
-private
+export
 toList :  Tree a
        -> List a
-toList (Balanced (_ ** arr))     = assert_total $ concat (map toList (toList arr))
-toList (Unbalanced (_ ** arr) _) = assert_total $ concat (map toList (toList arr))
-toList (Leaf (_ ** arr))         = toList arr
+toList (Balanced (_ ** arr))     =
+  assert_total $ concat (map toList (toList arr))
+toList (Unbalanced (_ ** arr) _) =
+  assert_total $ concat (map toList (toList arr))
+toList (Leaf (_ ** arr))         =
+  toList arr
 
 --------------------------------------------------------------------------------
 --          Interfaces (Tree)

--- a/src/Data/RRBVector1/Sized.idr
+++ b/src/Data/RRBVector1/Sized.idr
@@ -763,7 +763,7 @@ viewr v@(Root _ tree) t =
 
 private
 mapTree :  {n : Nat}
-        -> (F1 s a -> F1 s b)
+        -> (a -> b)
         -> (arr : MArray s n (Tree1 s a))
         -> F1 s (MArray s n (Tree1 s b))
 mapTree f arr t =
@@ -810,7 +810,7 @@ mapTree f arr t =
 ||| Apply the function to every element. O(n)
 export
 map :  {n : Nat}
-    -> (F1 s a -> F1 s b)
+    -> (a -> b)
     -> RRBVector1 s n a
     -> F1 s (n' ** RRBVector1 s n' b)
 map _ Empty                                   t =

--- a/src/Data/RRBVector1/Unsized.idr
+++ b/src/Data/RRBVector1/Unsized.idr
@@ -749,7 +749,7 @@ viewr v@(Root size _ tree) t =
 
 private
 mapTree :  {n : Nat}
-        -> (F1 s a -> F1 s b)
+        -> (a -> b)
         -> (arr : MArray s n (Tree1 s a))
         -> F1 s (MArray s n (Tree1 s b))
 mapTree f arr t =
@@ -795,7 +795,7 @@ mapTree f arr t =
 
 ||| Apply the function to every element. O(n)
 export
-map :  (F1 s a -> F1 s b)
+map :  (a -> b)
     -> RRBVector1 s a
     -> F1 s (RRBVector1 s b)
 map _ Empty                                        t =


### PR DESCRIPTION
This PR fixes the `Eq` implementation for `RRBVector` (`Sized`).

This also fixes `map`/`mapTree` for `RRBVector1` (`Sized` and `Unsized`).