### PR TITLE
[ refactor ] RRBVector1 mmap

### DIFF
--- a/src/Data/RRBVector1/Sized.idr
+++ b/src/Data/RRBVector1/Sized.idr
@@ -763,9 +763,9 @@ viewr v@(Root _ tree) t =
 
 private
 mapTree :  {n : Nat}
-        -> (a -> b)
+        -> (a -> a)
         -> (arr : MArray s n (Tree1 s a))
-        -> F1 s (MArray s n (Tree1 s b))
+        -> F1 s (MArray s n (Tree1 s a))
 mapTree f arr t =
   let tmt # t := unsafeMArray1 n t
     in go 0 n tmt t
@@ -810,9 +810,9 @@ mapTree f arr t =
 ||| Apply the function to every element. O(n)
 export
 map :  {n : Nat}
-    -> (a -> b)
+    -> (a -> a)
     -> RRBVector1 s n a
-    -> F1 s (n' ** RRBVector1 s n' b)
+    -> F1 s (n' ** RRBVector1 s n' a)
 map _ Empty                                   t =
   (0 ** Empty) # t
 map f (Root sh (Balanced (b ** arr)))         t =

--- a/src/Data/RRBVector1/Sized.idr
+++ b/src/Data/RRBVector1/Sized.idr
@@ -802,9 +802,9 @@ mapTree f arr t =
                  Nothing =>
                    (assert_total $ idris_crash "Data.RRBVector.mapTree.go: can't convert Nat to Fin") # t
                  Just m' =>
-                   let arr''' # t := mmap f arr'' t
-                       arr''''    := Leaf {lsize=l} (l ** arr''')
-                       ()     # t := set arr' m' arr'''' t
+                   let ()    # t := mupdate f arr'' t
+                       arr'''    := Leaf {lsize=l} (l ** arr'')
+                       ()    # t := set arr' m' arr''' t
                      in go (S m) j arr' t
 
 ||| Apply the function to every element. O(n)
@@ -824,9 +824,9 @@ map f (Root sh (Unbalanced (u ** arr) sizes)) t =
       arr''    := Unbalanced (u ** arr') sizes
     in (n ** Root sh arr'') # t
 map f (Root sh (Leaf (l ** arr)))             t =
-  let arr' # t := mmap f arr t
-      arr''    := Leaf {lsize=l} (l ** arr')
-    in (n ** Root sh arr'') # t
+  let ()   # t := mupdate f arr t
+      arr'     := Leaf {lsize=l} (l ** arr)
+    in (n ** Root sh arr') # t
 
 --------------------------------------------------------------------------------
 --          Concatenation

--- a/src/Data/RRBVector1/Sized.idr
+++ b/src/Data/RRBVector1/Sized.idr
@@ -767,13 +767,12 @@ mapTree :  {n : Nat}
         -> (arr : MArray s n (Tree1 s a))
         -> F1 s (MArray s n (Tree1 s a))
 mapTree f arr t =
-  let tmt # t := unsafeMArray1 n t
-    in go 0 n tmt t
+  go 0 n arr t
   where
     go :  (m, x : Nat)
-       -> (arr' : MArray s n (Tree1 s b))
+       -> (arr' : MArray s n (Tree1 s a))
        -> {auto v : Ix x n}
-       -> F1 s (MArray s n (Tree1 s b))
+       -> F1 s (MArray s n (Tree1 s a))
     go m Z     arr' t =
       arr' # t
     go m (S j) arr' t =

--- a/src/Data/RRBVector1/Unsized.idr
+++ b/src/Data/RRBVector1/Unsized.idr
@@ -753,13 +753,12 @@ mapTree :  {n : Nat}
         -> (arr : MArray s n (Tree1 s a))
         -> F1 s (MArray s n (Tree1 s a))
 mapTree f arr t =
-  let tmt # t := unsafeMArray1 n t
-    in go 0 n tmt t
+  go 0 n arr t
   where
     go :  (m, x : Nat)
-       -> (arr' : MArray s n (Tree1 s b))
+       -> (arr' : MArray s n (Tree1 s a))
        -> {auto v : Ix x n}
-       -> F1 s (MArray s n (Tree1 s b))
+       -> F1 s (MArray s n (Tree1 s a))
     go m Z     arr' t =
       arr' # t
     go m (S j) arr' t =

--- a/src/Data/RRBVector1/Unsized.idr
+++ b/src/Data/RRBVector1/Unsized.idr
@@ -788,9 +788,9 @@ mapTree f arr t =
                  Nothing =>
                    (assert_total $ idris_crash "Data.RRBVector.mapTree.go: can't convert Nat to Fin") # t
                  Just m' =>
-                   let arr''' # t := mmap f arr'' t
-                       arr''''    := Leaf {lsize=l} (l ** arr''')
-                       ()     # t := set arr' m' arr'''' t
+                   let ()     # t := mupdate f arr'' t
+                       arr'''     := Leaf {lsize=l} (l ** arr'')
+                       ()     # t := set arr' m' arr''' t
                      in go (S m) j arr' t
 
 ||| Apply the function to every element. O(n)
@@ -809,9 +809,9 @@ map f (Root size sh (Unbalanced (u ** arr) sizes)) t =
       arr''    := Unbalanced (u ** arr') sizes
     in (Root size sh arr'') # t
 map f (Root size sh (Leaf (l ** arr)))             t =
-  let arr' # t := mmap f arr t
-      arr''    := Leaf {lsize=l} (l ** arr')
-    in (Root size sh arr'') # t
+  let ()  # t := mupdate f arr t
+      arr'    := Leaf {lsize=l} (l ** arr)
+    in (Root size sh arr') # t
 
 --------------------------------------------------------------------------------
 --          Concatenation

--- a/src/Data/RRBVector1/Unsized.idr
+++ b/src/Data/RRBVector1/Unsized.idr
@@ -749,9 +749,9 @@ viewr v@(Root size _ tree) t =
 
 private
 mapTree :  {n : Nat}
-        -> (a -> b)
+        -> (a -> a)
         -> (arr : MArray s n (Tree1 s a))
-        -> F1 s (MArray s n (Tree1 s b))
+        -> F1 s (MArray s n (Tree1 s a))
 mapTree f arr t =
   let tmt # t := unsafeMArray1 n t
     in go 0 n tmt t
@@ -795,9 +795,9 @@ mapTree f arr t =
 
 ||| Apply the function to every element. O(n)
 export
-map :  (a -> b)
+map :  (a -> a)
     -> RRBVector1 s a
-    -> F1 s (RRBVector1 s b)
+    -> F1 s (RRBVector1 s a)
 map _ Empty                                        t =
   empty t
 map f (Root size sh (Balanced (b ** arr)))         t =


### PR DESCRIPTION
This PR refactors `RRBVector1` to utililze `mupdate` instead of `mmap`.