### PR TITLE
[ refactor ] Unifying interface implementations for RRBVector (Sized and Unsized)

### DIFF
--- a/src/Data/RRBVector/Sized/Internal.idr
+++ b/src/Data/RRBVector/Sized/Internal.idr
@@ -219,6 +219,18 @@ Ord a => Ord (Tree a) where
     compare arr1 arr2
   compare (Leaf (_ ** arr1)) (Leaf (_ ** arr2))                 =
     compare arr1 arr2
+  compare (Balanced _) (Unbalanced _ _)                         =
+    LT
+  compare (Balanced _) (Leaf _)                                 =
+    LT
+  compare (Unbalanced _ _) (Balanced _)                         =
+    GT
+  compare (Unbalanced _ _) (Leaf _)                             =
+    LT
+  compare (Leaf _) (Balanced _)                                 =
+    GT
+  compare (Leaf _) (Unbalanced _ _)                             =
+    GT
 
 --------------------------------------------------------------------------------
 --          Show Utilities (Tree)

--- a/src/Data/RRBVector/Sized/Internal.idr
+++ b/src/Data/RRBVector/Sized/Internal.idr
@@ -213,24 +213,8 @@ Eq a => Eq (Tree a) where
 
 public export
 Ord a => Ord (Tree a) where
-  compare (Balanced (_ ** arr1)) (Balanced (_ ** arr2))         =
-    compare arr1 arr2
-  compare (Unbalanced (_ ** arr1) _) (Unbalanced (_ ** arr2) _) =
-    compare arr1 arr2
-  compare (Leaf (_ ** arr1)) (Leaf (_ ** arr2))                 =
-    compare arr1 arr2
-  compare (Balanced _) (Unbalanced _ _)                         =
-    LT
-  compare (Balanced _) (Leaf _)                                 =
-    LT
-  compare (Unbalanced _ _) (Balanced _)                         =
-    GT
-  compare (Unbalanced _ _) (Leaf _)                             =
-    LT
-  compare (Leaf _) (Balanced _)                                 =
-    GT
-  compare (Leaf _) (Unbalanced _ _)                             =
-    GT
+  compare tree1 tree2 =
+    compare (Data.RRBVector.Sized.Internal.toList tree1) (Data.RRBVector.Sized.Internal.toList tree2)
 
 --------------------------------------------------------------------------------
 --          Show Utilities (Tree)

--- a/src/Data/RRBVector/Sized/Internal.idr
+++ b/src/Data/RRBVector/Sized/Internal.idr
@@ -203,18 +203,22 @@ Foldable Tree where
 public export
 Eq a => Eq (Tree a) where
   (Balanced (bsize1 ** arr1)) == (Balanced (bsize2 ** arr2))         =
-    assert_total $ bsize1 == bsize2 && toList arr1 == toList arr2
+    assert_total $ bsize1 == bsize2 && arr1 == arr2
   (Unbalanced (usize1 ** arr1) _) == (Unbalanced (usize2 ** arr2) _) =
-    assert_total $ usize1 == usize2 && toList arr1 == toList arr2
+    assert_total $ usize1 == usize2 && arr1 == arr2
   (Leaf (lsize1 ** arr1)) == (Leaf (lsize2 ** arr2))                 =
-    lsize1 == lsize2 && toList arr1 == toList arr2
+    lsize1 == lsize2 && arr1 == arr2
   _                        == _                                      =
     False
 
 public export
 Ord a => Ord (Tree a) where
-  compare tree1 tree2 =
-    compare (Data.RRBVector.Sized.Internal.toList tree1) (Data.RRBVector.Sized.Internal.toList tree2)
+  compare (Balanced (_ ** arr1)) (Balanced (_ ** arr2))         =
+    compare arr1 arr2
+  compare (Unbalanced (_ ** arr1) _) (Unbalanced (_ ** arr2) _) =
+    compare arr1 arr2
+  compare (Leaf (_ ** arr1)) (Leaf (_ ** arr2))                 =
+    compare arr1 arr2
 
 --------------------------------------------------------------------------------
 --          Show Utilities (Tree)

--- a/src/Data/RRBVector/Unsized/Internal.idr
+++ b/src/Data/RRBVector/Unsized/Internal.idr
@@ -166,6 +166,20 @@ foldr f acc tree =
       assert_total $ foldr f acc' arr
 
 --------------------------------------------------------------------------------
+--          Creating Lists from Trees
+--------------------------------------------------------------------------------
+
+export
+toList :  Tree a
+       -> List a
+toList (Balanced arr)     =
+  assert_total $ concat (map toList (toList arr))
+toList (Unbalanced arr _) =
+  assert_total $ concat (map toList (toList arr))
+toList (Leaf arr)         =
+  toList arr
+
+--------------------------------------------------------------------------------
 --          Interfaces (Tree)
 --------------------------------------------------------------------------------
 

--- a/src/Data/RRBVector/Unsized/Internal.idr
+++ b/src/Data/RRBVector/Unsized/Internal.idr
@@ -221,15 +221,15 @@ Ord a => Ord (Tree a) where
   compare (Balanced arr1) (Unbalanced arr2 _)     =
     compare arr1 arr2
   compare (Balanced arr1) (Leaf arr2)             =
-    compare (toList arr1) (toList arr2)
+    compare (concat $ map toList arr1) (toList arr2)
   compare (Unbalanced arr1 _) (Balanced arr2)     =
     compare arr1 arr2
   compare (Unbalanced arr1 _) (Leaf arr2)         =
-    compare (toList arr1) (toList arr2)
+    compare (concat $ map toList arr1) (toList arr2)
   compare (Leaf arr1) (Balanced arr2)             =
-    compare (toList arr1) (toList arr2)
+    compare (toList arr1) (concat $ map toList arr2)
   compare (Leaf arr1) (Unbalanced arr2 _)         =
-    compare (toList arr1) (toList arr2)
+    compare (toList arr1) (concat $ map toList arr2)
 
 --------------------------------------------------------------------------------
 --          Show Utilities (Tree)

--- a/src/Data/RRBVector/Unsized/Internal.idr
+++ b/src/Data/RRBVector/Unsized/Internal.idr
@@ -221,15 +221,15 @@ Ord a => Ord (Tree a) where
   compare (Balanced arr1) (Unbalanced arr2 _)     =
     compare arr1 arr2
   compare (Balanced arr1) (Leaf arr2)             =
-    compare arr1 arr2
+    compare (toList arr1) (toList arr2)
   compare (Unbalanced arr1 _) (Balanced arr2)     =
     compare arr1 arr2
   compare (Unbalanced arr1 _) (Leaf arr2)         =
-    compare arr1 arr2
+    compare (toList arr1) (toList arr2)
   compare (Leaf arr1) (Balanced arr2)             =
-    compare arr1 arr2
+    compare (toList arr1) (toList arr2)
   compare (Leaf arr1) (Unbalanced arr2 _)         =
-    compare arr1 arr2
+    compare (toList arr1) (toList arr2)
 
 --------------------------------------------------------------------------------
 --          Show Utilities (Tree)

--- a/src/Data/RRBVector/Unsized/Internal.idr
+++ b/src/Data/RRBVector/Unsized/Internal.idr
@@ -110,7 +110,100 @@ data Tree a = Balanced (Array (Tree a))
             | Unbalanced (Array (Tree a)) (Array Nat)
             | Leaf (Array a)
 
-%runElab derive "Tree" [Eq,Ord,Show]
+--------------------------------------------------------------------------------
+--          Query (Tree)
+--------------------------------------------------------------------------------
+
+||| Is the tree empty? O(1)
+private
+null :  Tree a
+     -> Bool
+null (Balanced arr)     =
+  null arr
+null (Unbalanced arr _) =
+  null arr
+null (Leaf arr)         =
+  null arr
+
+--------------------------------------------------------------------------------
+--          Folds (Tree)
+--------------------------------------------------------------------------------
+
+private
+foldl :  (b -> a -> b)
+      -> b
+      -> Tree a
+      -> b
+foldl f acc tree =
+  foldlTree acc tree
+  where
+    foldlTree :  b
+              -> Tree a
+              -> b
+    foldlTree acc' (Balanced arr)     =
+      assert_total $ foldl foldlTree acc' arr
+    foldlTree acc' (Unbalanced arr _) =
+      assert_total $ foldl foldlTree acc' arr
+    foldlTree acc' (Leaf arr)         =
+      assert_total $ foldl f acc' arr
+
+private
+foldr :  (a -> b -> b)
+      -> b
+      -> Tree a
+      -> b
+foldr f acc tree =
+  foldrTree tree acc
+  where
+    foldrTree :  Tree a
+              -> b
+              -> b
+    foldrTree (Balanced arr) acc'     =
+      assert_total $ foldr foldrTree acc' arr
+    foldrTree (Unbalanced arr _) acc' =
+      assert_total $ foldr foldrTree acc' arr
+    foldrTree (Leaf arr) acc'         =
+      assert_total $ foldr f acc' arr
+
+--------------------------------------------------------------------------------
+--          Interfaces (Tree)
+--------------------------------------------------------------------------------
+
+public export
+Show a => Show (Tree a) where
+  show (Balanced arr)     =
+    assert_total $ "Balanced " ++ show arr
+  show (Unbalanced arr _) =
+    assert_total $ "Unbalanced " ++ show arr
+  show (Leaf arr)         =
+    "Leaf " ++ show arr
+
+public export
+Foldable Tree where
+  foldl f z = Data.RRBVector.Unsized.Internal.foldl f z
+  foldr f z = Data.RRBVector.Unsized.Internal.foldr f z
+  toList    = Data.RRBVector.Unsized.Internal.toList
+  null      = Data.RRBVector.Unsized.Internal.null
+
+public export
+Eq a => Eq (Tree a) where
+  (Balanced arr1) == (Balanced arr2)         =
+    assert_total $ arr1 == arr2
+  (Unbalanced arr1 _) == (Unbalanced arr2 _) =
+    assert_total $ arr1 == arr2
+  (Leaf arr1) == (Leaf arr2)                 =
+    arr1 == arr2
+  _                        == _              =
+    False
+
+public export
+Ord a => Ord (Tree a) where
+  compare (Balanced arr1) (Balanced arr2)         =
+    compare arr1 arr2
+  compare (Unbalanced arr1 _) (Unbalanced arr2 _) =
+    compare arr1 arr2
+  compare (Leaf arr1) (Leaf arr2)                 =
+    compare arr1 arr2
 
 --------------------------------------------------------------------------------
 --          Show Utilities (Tree)

--- a/src/Data/RRBVector/Unsized/Internal.idr
+++ b/src/Data/RRBVector/Unsized/Internal.idr
@@ -213,11 +213,11 @@ Eq a => Eq (Tree a) where
 public export
 Ord a => Ord (Tree a) where
   compare (Balanced arr1) (Balanced arr2)         =
-    compare arr1 arr2
+    assert_total $ compare arr1 arr2
   compare (Unbalanced arr1 _) (Unbalanced arr2 _) =
-    compare arr1 arr2
+    assert_total $ compare arr1 arr2
   compare (Leaf arr1) (Leaf arr2)                 =
-    compare arr1 arr2
+    assert_total $ compare arr1 arr2
   compare (Balanced _) (Unbalanced _ _)           =
     LT
   compare (Balanced _) (Leaf _)                   =

--- a/src/Data/RRBVector/Unsized/Internal.idr
+++ b/src/Data/RRBVector/Unsized/Internal.idr
@@ -218,18 +218,18 @@ Ord a => Ord (Tree a) where
     compare arr1 arr2
   compare (Leaf arr1) (Leaf arr2)                 =
     compare arr1 arr2
-  compare (Balanced arr1) (Unbalanced arr2 _)     =
-    compare arr1 arr2
-  compare (Balanced arr1) (Leaf arr2)             =
-    compare (concat $ map Data.RRBVector.Unsized.Internal.toList arr1) (toList arr2)
-  compare (Unbalanced arr1 _) (Balanced arr2)     =
-    compare arr1 arr2
-  compare (Unbalanced arr1 _) (Leaf arr2)         =
-    compare (concat $ map Data.RRBVector.Unsized.Internal.toList arr1) (toList arr2)
-  compare (Leaf arr1) (Balanced arr2)             =
-    compare (toList arr1) (concat $ map Data.RRBVector.Unsized.Internal.toList arr2)
-  compare (Leaf arr1) (Unbalanced arr2 _)         =
-    compare (toList arr1) (concat $ map Data.RRBVector.Unsized.Internal.toList arr2)
+  compare (Balanced _) (Unbalanced _ _)           =
+    LT
+  compare (Balanced _) (Leaf _)                   =
+    LT
+  compare (Unbalanced _ _) (Balanced _)           =
+    GT
+  compare (Unbalanced _ _) (Leaf _)               =
+    LT
+  compare (Leaf _) (Balanced _)                   =
+    GT
+  compare (Leaf _) (Unbalanced _ _)               =
+    GT
 
 --------------------------------------------------------------------------------
 --          Show Utilities (Tree)

--- a/src/Data/RRBVector/Unsized/Internal.idr
+++ b/src/Data/RRBVector/Unsized/Internal.idr
@@ -221,15 +221,15 @@ Ord a => Ord (Tree a) where
   compare (Balanced arr1) (Unbalanced arr2 _)     =
     compare arr1 arr2
   compare (Balanced arr1) (Leaf arr2)             =
-    compare (concat $ map toList arr1) (toList arr2)
+    compare (concat $ map Data.RRBVector.Unsized.Internal.toList arr1) (toList arr2)
   compare (Unbalanced arr1 _) (Balanced arr2)     =
     compare arr1 arr2
   compare (Unbalanced arr1 _) (Leaf arr2)         =
-    compare (concat $ map toList arr1) (toList arr2)
+    compare (concat $ map Data.RRBVector.Unsized.Internal.toList arr1) (toList arr2)
   compare (Leaf arr1) (Balanced arr2)             =
-    compare (toList arr1) (concat $ map toList arr2)
+    compare (toList arr1) (concat $ map Data.RRBVector.Unsized.Internal.toList arr2)
   compare (Leaf arr1) (Unbalanced arr2 _)         =
-    compare (toList arr1) (concat $ map toList arr2)
+    compare (toList arr1) (concat $ map Data.RRBVector.Unsized.Internal.toList arr2)
 
 --------------------------------------------------------------------------------
 --          Show Utilities (Tree)

--- a/src/Data/RRBVector/Unsized/Internal.idr
+++ b/src/Data/RRBVector/Unsized/Internal.idr
@@ -212,24 +212,8 @@ Eq a => Eq (Tree a) where
 
 public export
 Ord a => Ord (Tree a) where
-  compare (Balanced arr1) (Balanced arr2)         =
-    assert_total $ compare arr1 arr2
-  compare (Unbalanced arr1 _) (Unbalanced arr2 _) =
-    assert_total $ compare arr1 arr2
-  compare (Leaf arr1) (Leaf arr2)                 =
-    assert_total $ compare arr1 arr2
-  compare (Balanced _) (Unbalanced _ _)           =
-    LT
-  compare (Balanced _) (Leaf _)                   =
-    LT
-  compare (Unbalanced _ _) (Balanced _)           =
-    GT
-  compare (Unbalanced _ _) (Leaf _)               =
-    LT
-  compare (Leaf _) (Balanced _)                   =
-    GT
-  compare (Leaf _) (Unbalanced _ _)               =
-    GT
+  compare tree1 tree2 =
+    compare (Data.RRBVector.Unsized.Internal.toList tree1) (Data.RRBVector.Unsized.Internal.toList tree2)
 
 --------------------------------------------------------------------------------
 --          Show Utilities (Tree)

--- a/src/Data/RRBVector/Unsized/Internal.idr
+++ b/src/Data/RRBVector/Unsized/Internal.idr
@@ -218,6 +218,18 @@ Ord a => Ord (Tree a) where
     compare arr1 arr2
   compare (Leaf arr1) (Leaf arr2)                 =
     compare arr1 arr2
+  compare (Balanced arr1) (Unbalanced arr2 _)     =
+    compare arr1 arr2
+  compare (Balanced arr1) (Leaf arr2)             =
+    compare arr1 arr2
+  compare (Unbalanced arr1 _) (Balanced arr2)     =
+    compare arr1 arr2
+  compare (Unbalanced arr1 _) (Leaf arr2)         =
+    compare arr1 arr2
+  compare (Leaf arr1) (Balanced arr2)             =
+    compare arr1 arr2
+  compare (Leaf arr1) (Unbalanced arr2 _)         =
+    compare arr1 arr2
 
 --------------------------------------------------------------------------------
 --          Show Utilities (Tree)


### PR DESCRIPTION
This PR unifies various `RRBVector` (Sized and Unsized) interface (`Eq`, `Ord`, and `Show`) implementations.