### PR TITLE
[ fix ] Seq1

### DIFF
--- a/src/Data/Seq/Unsized.idr
+++ b/src/Data/Seq/Unsized.idr
@@ -11,7 +11,7 @@ import Data.Seq.Internal
 %default total
 
 ||| A two-end finite sequence.
-export
+public export
 data Seq : Type -> Type where
   MkSeq :  FingerTree (Elem e)
         -> Seq e

--- a/src/Data/Seq/Unsized.idr
+++ b/src/Data/Seq/Unsized.idr
@@ -11,7 +11,7 @@ import Data.Seq.Internal
 %default total
 
 ||| A two-end finite sequence.
-public export
+export
 data Seq : Type -> Type where
   MkSeq :  FingerTree (Elem e)
         -> Seq e

--- a/src/Data/Seq1/Unsized.idr
+++ b/src/Data/Seq1/Unsized.idr
@@ -8,29 +8,30 @@ import Data.Linear.Ref1
 import public Data.Zippable
 
 import Data.Seq.Internal
+import Data.Seq.Unsized
 
 %default total
 
 ||| A linear two-end finite sequence.
 export
 data Seq1 : (s : Type) -> (e : Type) -> Type where
-  MkSeq1 : Ref s (FingerTree (Elem e))
+  MkSeq1 : Ref s (Seq e)
         -> Seq1 s e
 
 ||| O(1). The empty sequence.
 export
 empty : F1 s (Seq1 s e)
 empty t =
-  let tr # t := ref1 Empty t
-    in (MkSeq1 tr) # t
+  let seq # t := ref1 (MkSeq Empty) t
+    in (MkSeq1 seq) # t
 
 ||| O(1). A singleton sequence.
 export
 singleton :  e
           -> F1 s (Seq1 s e)
 singleton a t =
-  let tr # t := ref1 (Single (MkElem a)) t
-    in (MkSeq1 tr) # t
+  let seq # t := ref1 (MkSeq (Single (MkElem a))) t
+    in (MkSeq1 seq) # t
 
 ||| O(n). A sequence of length n with a the value of every element.
 export
@@ -38,24 +39,23 @@ replicate :  (n : Nat)
           -> (a : e)
           -> F1 s (Seq1 s e)
 replicate n a t =
-  let tr # t := ref1 (replicate' n a) t
-    in (MkSeq1 tr) # t
+  let seq # t := ref1 (MkSeq (replicate' n a)) t
+    in (MkSeq1 seq) # t
 
 ||| O(1). The number of elements in the sequence.
 export
 length :  Seq1 s a
        -> F1 s Nat
-length (MkSeq1 tr) t =
-  let tr' # t := read1 tr t
-    in (length' tr') # t
+length (MkSeq1 seq) t =
+  let (MkSeq seq') # t := read1 seq t
+    in (length' seq') # t
 
 ||| O(n). Reverse the sequence.
 export
 reverse :  Seq1 s a
         -> F1' s
-reverse (MkSeq1 tr) t =
-  let tr' # t := read1 tr t
-    in casswap1 tr (reverseTree id tr') t
+reverse (MkSeq1 seq) t =
+  casupdate1 seq (\(MkSeq tr) => (MkSeq (reverseTree id tr), ())) t
 
 export infixr 5 `cons`
 ||| O(1). Add an element to the left end of a sequence.
@@ -63,9 +63,8 @@ export
 cons :  e
      -> Seq1 s e
      -> F1' s
-(a `cons` (MkSeq1 tr)) t =
-  let tr' # t := read1 tr t
-    in casswap1 tr (MkElem a `consTree` tr') t
+(a `cons` (MkSeq1 seq)) t =
+  casupdate1 seq (\(MkSeq tr) => (MkSeq (MkElem a `consTree` tr), ())) t
 
 export infixl 5 `snoc`
 ||| O(1). Add an element to the right end of a sequence.
@@ -73,102 +72,97 @@ export
 snoc :  Seq1 s e
      -> e
      -> F1' s
-((MkSeq1 tr) `snoc` a) t =
-  let tr' # t := read1 tr t
-    in casswap1 tr (tr' `snocTree` MkElem a) t
-
-||| O(log(min(m, n))). Concatenate two sequences.
-export
-(++) :  Seq1 s e
-     -> Seq1 s e
-     -> F1 s (Seq1 s e)
-((MkSeq1 t1) ++ (MkSeq1 t2)) t =
-  let t1'  # t := read1 t1 t
-      t2'  # t := read1 t2 t
-      t1t2 # t := ref1 (addTree0 t1' t2') t
-    in (MkSeq1 t1t2) # t
+((MkSeq1 seq) `snoc` a) t =
+  casupdate1 seq (\(MkSeq tr) => (MkSeq (tr `snocTree` MkElem a), ())) t
 
 ||| O(1). View from the left of the sequence.
 export
 viewl :  Seq1 s e
       -> F1 s (Maybe (e, Seq1 s e))
-viewl (MkSeq1 tr) t =
-  let tr' # t := read1 tr t
-    in case viewLTree tr' of
-         Just (MkElem a, tr') =>
-           let () # t := casswap1 tr tr' t
-             in (Just (a, MkSeq1 tr)) # t
-         Nothing              =>
-           Nothing # t
+viewl (MkSeq1 seq) t =
+  casupdate1 seq
+    (\(MkSeq tr) =>
+      case viewLTree tr of
+        Just (MkElem a, tr') =>
+          (MkSeq tr', Just (a, MkSeq1 seq))
+        Nothing               =>
+          (MkSeq tr, Nothing)
+    ) t
 
 ||| O(1). The first element of the sequence.
 export
 head :  Seq1 s e
      -> F1 s (Maybe e)
-head seq t =
-  let seq' # t := viewl seq t
-    in case seq' of
-         Nothing     =>
-           Nothing # t
-         Just (h, _) =>
-           (Just h) # t
+head (MkSeq1 seq) t =
+  let MkSeq tr # t := read1 seq t
+   in case viewLTree tr of
+        Just (MkElem a, _) =>
+          Just a # t
+        Nothing            =>
+          Nothing # t
+
 ||| O(1). The elements after the head of the sequence.
 ||| Returns an empty sequence when the sequence is empty.
 export
 tail :  Seq1 s e
      -> F1 s (Seq1 s e)
-tail seq t =
-  let seq' # t := viewl seq t
-    in case seq' of
-         Just (_, seq'') =>
-           seq'' # t
-         Nothing          =>
-           empty t
+tail (MkSeq1 seq) t =
+  casupdate1 seq
+    (\(MkSeq tr) =>
+      case viewLTree tr of
+        Just (MkElem _, tr') =>
+          (MkSeq tr', MkSeq1 seq)
+        Nothing               =>
+          (MkSeq tr, MkSeq1 seq)
+    ) t
 
 ||| O(1). View from the right of the sequence.
 export
 viewr :  Seq1 s e
       -> F1 s (Maybe (Seq1 s e, e))
-viewr (MkSeq1 tr) t =
-  let tr' # t := read1 tr t
-    in case viewRTree tr' of
-         Just (tr', MkElem a) =>
-           let () # t := casswap1 tr tr' t
-             in (Just (MkSeq1 tr, a)) # t
-         Nothing              =>
-          Nothing # t
+viewr (MkSeq1 seq) t =
+  casupdate1 seq
+    (\(MkSeq tr) =>
+      case viewRTree tr of
+        Just (tr', MkElem a) =>
+          (MkSeq tr', Just (MkSeq1 seq, a))
+        Nothing               =>
+          (MkSeq tr, Nothing)
+    ) t
 
 ||| O(1). The elements before the last element of the sequence.
 ||| Returns an empty sequence when the sequence is empty.
 export
 init :  Seq1 s e
      -> F1 s (Seq1 s e)
-init seq t =
-  let seq' # t := viewr seq t
-    in case seq' of
-         Just (seq'', _) =>
-           seq'' # t
-         Nothing         =>
-           empty t
+init (MkSeq1 seq) t =
+  casupdate1 seq
+    (\(MkSeq tr) =>
+      case viewRTree tr of
+        Just (tr', MkElem _) =>
+          (MkSeq tr', MkSeq1 seq)
+        Nothing               =>
+          (MkSeq tr, MkSeq1 seq)
+    ) t
 
 ||| O(1). The last element of the sequence.
 export
 last :  Seq1 s e
      -> F1 s (Maybe e)
-last seq t =
-  let seq' # t := viewr seq t
-    in case seq' of
-         Nothing     =>
+last (MkSeq1 seq) t =
+  let MkSeq tr # t := read1 seq t
+    in case viewRTree tr of
+         Just (_, MkElem a) =>
+           Just a # t
+         Nothing            =>
            Nothing # t
-         Just (_, l) =>
-           (Just l) # t
 
 ||| O(n). Turn a list into a sequence.
 export
 fromList :  List e
          -> F1 s (Seq1 s e)
 fromList xs t =
-  let seq # t := ref1 (foldr (\x, t => MkElem x `consTree` t) Empty xs) t
+  let seq # t := ref1 (MkSeq (foldr (\x, tr => MkElem x `consTree` tr) Empty xs)) t
     in (MkSeq1 seq) # t
 
 ||| Turn a sequence into a list. O(n)
@@ -182,24 +176,24 @@ toList seq t =
        -> (sl : SnocList e)
        -> F1 s (List e)
     go seq sl t =
-      let seq' # t := viewl seq t
-        in case seq' of
-             Nothing         =>
+      let tr # t := Data.Seq1.Unsized.viewl seq t
+        in case tr of
+             Nothing       =>
                (sl <>> []) # t
-             Just (x, seq'') =>
-               (assert_total (go seq'' (sl :< x))) t
+             Just (x, tr') =>
+               (assert_total (go tr' (sl :< x))) t
 
 ||| O(log(min(i, n-i))). The element at the specified position.
 export
 index :  Nat
       -> Seq1 s e
       -> F1 s (Maybe e)
-index i (MkSeq1 tr) t =
-  let tr' # t := read1 tr t
-    in case i < length' tr' of
+index i (MkSeq1 seq) t =
+  let MkSeq tr # t := read1 seq t
+    in case i < length' tr of
          True  =>
-           let (_, MkElem a) := lookupTree i tr'
-             in (Just a) # t
+           let (_, MkElem a) := lookupTree i tr
+            in Just a # t
          False =>
            Nothing # t
 
@@ -209,15 +203,16 @@ export
 adjust :  (e -> e)
        -> Nat
        -> Seq1 s e
-       -> F1 s (Seq1 s e)
-adjust f i (MkSeq1 tr) t =
-  let tr' # t := read1 tr t
-    in case i < length' tr' of
-         True  =>
-           let () # t := casswap1 tr (adjustTree (const (map f)) i tr') t
-             in (MkSeq1 tr) # t
-         False =>
-           (MkSeq1 tr) # t
+       -> F1' s
+adjust f i (MkSeq1 seq) t =
+  casupdate1 seq
+    (\(MkSeq tr) =>
+      case i < length' tr of
+        True  =>
+          (MkSeq (adjustTree (const (map f)) i tr), ())
+        False =>
+          (MkSeq tr, ())
+    ) t
 
 ||| O(log(min(i, n-i))). Replace the element at the specified position.
 ||| If the position is out of range, the original sequence is returned.
@@ -225,53 +220,15 @@ export
 update :  Nat
        -> e
        -> Seq1 s e
-       -> F1 s (Seq1 s e)
+       -> F1' s
 update i a seq t =
   adjust (const a) i seq t
-
-||| O(log(min(i, n-i))). Split a sequence at a given position.
-||| splitAt i s = (take i s, drop i s)
-export
-splitAt :  Nat
-        -> Seq1 s e
-        -> F1 s ((Seq1 s e, Seq1 s e))
-splitAt i (MkSeq1 tr) t =
-  let tr' # t := read1 tr t
-    in case i < length' tr' of
-         True  =>
-           let (l, r) := split i tr'
-               l' # t := ref1 l t
-               r' # t := ref1 r t
-             in (MkSeq1 l', MkSeq1 r') # t
-         False =>
-           let seq' # t := Data.Seq1.Unsized.empty t
-             in (MkSeq1 tr, seq') # t
-
-||| O(log(min(i,n-i))). The first i elements of a sequence.
-||| If the sequence contains fewer than i elements, the whole sequence is returned.
-export
-take :  Nat
-     -> Seq1 s e
-     -> F1 s (Seq1 s e)
-take i seq t =
-  let (seq1, _) # t := Data.Seq1.Unsized.splitAt i seq t
-    in seq1 # t
-
-||| O(log(min(i,n-i))). Elements of a sequence after the first i.
-||| If the sequence contains fewer than i elements, the empty sequence is returned.
-export
-drop :  Nat
-     -> Seq1 s e
-     -> F1 s (Seq1 s e)
-drop i seq t =
-  let (_, seq2) # t := Data.Seq1.Unsized.splitAt i seq t
-    in seq2 # t
 
 ||| Dump the internal structure of the finger tree.
 export
 show' :  Show e
       => Seq1 s e
       -> F1 s String
-show' (MkSeq1 tr) t =
-  let tr' # t := read1 tr t
-    in (showPrec Open tr') # t
+show' (MkSeq1 seq) t =
+  let MkSeq tr # t := read1 seq t
+    in (showPrec Open tr) # t

--- a/src/Data/Seq1/Unsized.idr
+++ b/src/Data/Seq1/Unsized.idr
@@ -8,30 +8,29 @@ import Data.Linear.Ref1
 import public Data.Zippable
 
 import Data.Seq.Internal
-import Data.Seq.Unsized
 
 %default total
 
 ||| A linear two-end finite sequence.
 export
 data Seq1 : (s : Type) -> (e : Type) -> Type where
-  MkSeq1 : Ref s (Seq e)
+  MkSeq1 : Ref s (FingerTree (Elem e))
         -> Seq1 s e
 
 ||| O(1). The empty sequence.
 export
 empty : F1 s (Seq1 s e)
 empty t =
-  let seq # t := ref1 (MkSeq Empty) t
-    in (MkSeq1 seq) # t
+  let tr # t := ref1 Empty t
+    in MkSeq1 tr # t
 
 ||| O(1). A singleton sequence.
 export
 singleton :  e
           -> F1 s (Seq1 s e)
 singleton a t =
-  let seq # t := ref1 (MkSeq (Single (MkElem a))) t
-    in (MkSeq1 seq) # t
+  let tr # t := ref1 (Single (MkElem a)) t
+    in MkSeq1 tr # t
 
 ||| O(n). A sequence of length n with a the value of every element.
 export
@@ -39,23 +38,23 @@ replicate :  (n : Nat)
           -> (a : e)
           -> F1 s (Seq1 s e)
 replicate n a t =
-  let seq # t := ref1 (MkSeq (replicate' n a)) t
-    in (MkSeq1 seq) # t
+  let tr # t := ref1 (replicate' n a) t
+    in MkSeq1 tr # t
 
 ||| O(1). The number of elements in the sequence.
 export
 length :  Seq1 s a
        -> F1 s Nat
-length (MkSeq1 seq) t =
-  let (MkSeq seq') # t := read1 seq t
-    in (length' seq') # t
+length (MkSeq1 tr) t =
+  let tr' # t := read1 tr t
+    in length' tr' # t
 
 ||| O(n). Reverse the sequence.
 export
 reverse :  Seq1 s a
         -> F1' s
-reverse (MkSeq1 seq) t =
-  casupdate1 seq (\(MkSeq tr) => (MkSeq (reverseTree id tr), ())) t
+reverse (MkSeq1 tr) t =
+  casmod1 tr (\tr' => reverseTree id tr') t
 
 export infixr 5 `cons`
 ||| O(1). Add an element to the left end of a sequence.
@@ -63,8 +62,8 @@ export
 cons :  e
      -> Seq1 s e
      -> F1' s
-(a `cons` (MkSeq1 seq)) t =
-  casupdate1 seq (\(MkSeq tr) => (MkSeq (MkElem a `consTree` tr), ())) t
+(a `cons` (MkSeq1 tr)) t =
+  casmod1 tr (\tr' => MkElem a `consTree` tr') t
 
 export infixl 5 `snoc`
 ||| O(1). Add an element to the right end of a sequence.
@@ -72,30 +71,30 @@ export
 snoc :  Seq1 s e
      -> e
      -> F1' s
-((MkSeq1 seq) `snoc` a) t =
-  casupdate1 seq (\(MkSeq tr) => (MkSeq (tr `snocTree` MkElem a), ())) t
+((MkSeq1 tr) `snoc` a) t =
+  casmod1 tr (\tr' => tr' `snocTree` MkElem a) t
 
 ||| O(1). View from the left of the sequence.
 export
 viewl :  Seq1 s e
       -> F1 s (Maybe (e, Seq1 s e))
-viewl (MkSeq1 seq) t =
-  casupdate1 seq
-    (\(MkSeq tr) =>
-      case viewLTree tr of
-        Just (MkElem a, tr') =>
-          (MkSeq tr', Just (a, MkSeq1 seq))
+viewl (MkSeq1 tr) t =
+  casupdate1 tr
+    (\tr' =>
+      case viewLTree tr' of
+        Just (MkElem a, tr'') =>
+          (tr'', Just (a, MkSeq1 tr))
         Nothing               =>
-          (MkSeq tr, Nothing)
+          (tr', Nothing)
     ) t
 
 ||| O(1). The first element of the sequence.
 export
 head :  Seq1 s e
      -> F1 s (Maybe e)
-head (MkSeq1 seq) t =
-  let MkSeq tr # t := read1 seq t
-   in case viewLTree tr of
+head (MkSeq1 tr) t =
+  let tr' # t := read1 tr t
+   in case viewLTree tr' of
         Just (MkElem a, _) =>
           Just a # t
         Nothing            =>
@@ -105,53 +104,53 @@ head (MkSeq1 seq) t =
 ||| Returns an empty sequence when the sequence is empty.
 export
 tail :  Seq1 s e
-     -> F1 s (Seq1 s e)
-tail (MkSeq1 seq) t =
-  casupdate1 seq
-    (\(MkSeq tr) =>
-      case viewLTree tr of
-        Just (MkElem _, tr') =>
-          (MkSeq tr', MkSeq1 seq)
+     -> F1' s
+tail (MkSeq1 tr) t =
+  casmod1 tr
+    (\tr' =>
+      case viewLTree tr' of
+        Just (MkElem _, tr'') =>
+          tr''
         Nothing               =>
-          (MkSeq tr, MkSeq1 seq)
+          tr'
     ) t
 
 ||| O(1). View from the right of the sequence.
 export
 viewr :  Seq1 s e
       -> F1 s (Maybe (Seq1 s e, e))
-viewr (MkSeq1 seq) t =
-  casupdate1 seq
-    (\(MkSeq tr) =>
-      case viewRTree tr of
-        Just (tr', MkElem a) =>
-          (MkSeq tr', Just (MkSeq1 seq, a))
+viewr (MkSeq1 tr) t =
+  casupdate1 tr
+    (\tr' =>
+      case viewRTree tr' of
+        Just (tr'', MkElem a) =>
+          (tr'', Just (MkSeq1 tr, a))
         Nothing               =>
-          (MkSeq tr, Nothing)
+          (tr', Nothing)
     ) t
 
 ||| O(1). The elements before the last element of the sequence.
 ||| Returns an empty sequence when the sequence is empty.
 export
 init :  Seq1 s e
-     -> F1 s (Seq1 s e)
-init (MkSeq1 seq) t =
-  casupdate1 seq
-    (\(MkSeq tr) =>
-      case viewRTree tr of
-        Just (tr', MkElem _) =>
-          (MkSeq tr', MkSeq1 seq)
+     -> F1' s
+init (MkSeq1 tr) t =
+  casmod1 tr
+    (\tr' =>
+      case viewRTree tr' of
+        Just (tr'', MkElem _) =>
+          tr''
         Nothing               =>
-          (MkSeq tr, MkSeq1 seq)
+          tr'
     ) t
 
 ||| O(1). The last element of the sequence.
 export
 last :  Seq1 s e
      -> F1 s (Maybe e)
-last (MkSeq1 seq) t =
-  let MkSeq tr # t := read1 seq t
-    in case viewRTree tr of
+last (MkSeq1 tr) t =
+  let tr' # t := read1 tr t
+    in case viewRTree tr' of
          Just (_, MkElem a) =>
            Just a # t
          Nothing            =>
@@ -162,8 +161,8 @@ export
 fromList :  List e
          -> F1 s (Seq1 s e)
 fromList xs t =
-  let seq # t := ref1 (MkSeq (foldr (\x, tr => MkElem x `consTree` tr) Empty xs)) t
-    in (MkSeq1 seq) # t
+  let tr # t := ref1 (foldr (\x, acc => MkElem x `consTree` acc) Empty xs) t
+    in (MkSeq1 tr) # t
 
 ||| Turn a sequence into a list. O(n)
 export
@@ -188,11 +187,11 @@ export
 index :  Nat
       -> Seq1 s e
       -> F1 s (Maybe e)
-index i (MkSeq1 seq) t =
-  let MkSeq tr # t := read1 seq t
-    in case i < length' tr of
+index i (MkSeq1 tr) t =
+  let tr' # t := read1 tr t
+    in case i < length' tr' of
          True  =>
-           let (_, MkElem a) := lookupTree i tr
+           let (_, MkElem a) := lookupTree i tr'
             in Just a # t
          False =>
            Nothing # t
@@ -204,14 +203,13 @@ adjust :  (e -> e)
        -> Nat
        -> Seq1 s e
        -> F1' s
-adjust f i (MkSeq1 seq) t =
-  casupdate1 seq
-    (\(MkSeq tr) =>
-      case i < length' tr of
+adjust f i (MkSeq1 tr) t =
+  casmod1 tr
+    (\tr' =>
+      case i < length' tr' of
         True  =>
-          (MkSeq (adjustTree (const (map f)) i tr), ())
-        False =>
-          (MkSeq tr, ())
+          adjustTree (const (map f)) i tr'
+        False => tr'
     ) t
 
 ||| O(log(min(i, n-i))). Replace the element at the specified position.
@@ -229,6 +227,6 @@ export
 show' :  Show e
       => Seq1 s e
       -> F1 s String
-show' (MkSeq1 seq) t =
-  let MkSeq tr # t := read1 seq t
-    in (showPrec Open tr) # t
+show' (MkSeq1 tr) t =
+  let tr' # t := read1 tr t
+    in showPrec Open tr' # t

--- a/test/src/Concurrent/Seq1.idr
+++ b/test/src/Concurrent/Seq1.idr
@@ -1,0 +1,36 @@
+module Concurrent.Seq1
+
+import Data.Seq.Internal
+import Data.Seq.Unsized
+import Data.Seq1.Unsized
+import Data.Linear.Ref1
+import Data.Vect as V
+import System
+import System.Concurrency
+
+%default total
+
+ITER : Nat
+ITER = 10_000
+
+DELAY : Nat
+DELAY = 100_000
+
+inc : Seq1 s Nat -> Nat -> F1' s
+inc seq 0     t = snoc seq Z t
+inc seq (S k) t = snoc seq k t
+
+prog : Seq1 World Nat -> IO ()
+prog q = runIO (forN ITER $ inc q DELAY)
+
+runProg : Nat -> IO (List Nat)
+runProg n = do
+  q  <- runIO empty
+  ts <- sequence $ V.replicate n (fork $ prog q)
+  traverse_ (\t => threadWait t) ts
+  runIO (toList q)
+
+main : IO ()
+main = do
+  us <- runProg 4
+  printLn (length us)

--- a/test/src/Seq1/Unsized.idr
+++ b/test/src/Seq1/Unsized.idr
@@ -47,16 +47,6 @@ prop_snoc = property $ do
           _   # t := Data.Seq1.Unsized.snoc vs' 1 t
         in Data.Seq1.Unsized.toList vs' t ) === vs ++ [1]
 
-prop_concat : Property
-prop_concat = property $ do
-  xs <- forAll (list (linear 0 20) anyBits8)
-  ys <- forAll (list (linear 0 20) anyBits8)
-  ( run1 $ \t =>
-      let xs'  # t := Data.Seq1.Unsized.fromList xs t
-          ys'  # t := Data.Seq1.Unsized.fromList ys t
-          xsys # t := Data.Seq1.Unsized.(++) xs' ys' t
-        in Data.Seq1.Unsized.toList xsys t ) === xs ++ ys
-
 export
 props : Group
 props = MkGroup "Seq1 (Unsized)"
@@ -65,5 +55,4 @@ props = MkGroup "Seq1 (Unsized)"
   , ("prop_replicate", prop_replicate)
   , ("prop_cons", prop_cons)
   , ("prop_snoc", prop_snoc)
-  , ("prop_concat", prop_concat)
   ]


### PR DESCRIPTION
This PR fixes the `Seq1` implementation by utilizing `casupdate1` to ensure thread-safe operations.

Closes #63